### PR TITLE
Remove the stale code

### DIFF
--- a/cmd/image/image.go
+++ b/cmd/image/image.go
@@ -1,7 +1,6 @@
 package image
 
 import (
-	"fmt"
 	_import "github.com/ppc64le-cloud/pvsadm/cmd/image/import"
 	"github.com/ppc64le-cloud/pvsadm/cmd/image/qcow2ova"
 	"github.com/ppc64le-cloud/pvsadm/cmd/image/upload"
@@ -12,10 +11,6 @@ var Cmd = &cobra.Command{
 	Use:   "image",
 	Short: "PowerVS Image management",
 	Long:  `PowerVS Image management`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		fmt.Println("To Be Implemented...")
-		return nil
-	},
 }
 
 func init() {


### PR DESCRIPTION
Fixes: https://github.com/ppc64le-cloud/pvsadm/issues/23

will fix the following error:

```shell
╰─▶ ./pvsadm-darwin-amd64 image
To Be Implemented...
```

After fixing this issue, o/p looks like:

```shell
╰─$ ./pvsadm image            
PowerVS Image management

Usage:
  pvsadm image [command]

Available Commands:
  import      Import the image into PowerVS instances
  qcow2ova    Convert the qcow2 image to ova format
  upload      Upload the image to the IBM COS

Flags:
  -h, --help   help for image

Global Flags:
  -k, --api-key string      IBMCLOUD API Key(env name: IBMCLOUD_API_KEY)
      --audit-file string   Audit logs for the tool (default "pvsadm.log")
      --debug               Enable PowerVS debug option

Use "pvsadm image [command] --help" for more information about a command.

```