### PR TITLE
Print the out and err to start standard out and err

### DIFF
--- a/cmd/image/qcow2ova/prep/templates.go
+++ b/cmd/image/qcow2ova/prep/templates.go
@@ -11,7 +11,7 @@ var setup = `#!/bin/bash
 set -o errexit
 set -o nounset
 set -o pipefail
-set -o xtrace
+
 mv /etc/resolv.conf /etc/resolv.conf.orig | true
 echo "nameserver 9.9.9.9" | tee /etc/resolv.conf
 {{if eq .Dist "rhel"}}

--- a/pkg/utils/cmd_exec.go
+++ b/pkg/utils/cmd_exec.go
@@ -2,6 +2,8 @@ package utils
 
 import (
 	"bytes"
+	"io"
+	"os"
 	"os/exec"
 )
 
@@ -11,8 +13,8 @@ func RunCMD(cmd string, args ...string) (int, string, string) {
 	var stdout, stderr bytes.Buffer
 	c := exec.Command(cmd, args...)
 
-	c.Stdout = &stdout
-	c.Stderr = &stderr
+	c.Stdout = io.MultiWriter(os.Stdout, &stdout)
+	c.Stderr = io.MultiWriter(os.Stderr, &stderr)
 	if err := c.Run(); err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
 			return exitError.ExitCode(), stdout.String(), stderr.String()


### PR DESCRIPTION
Changes made:

- Removed xtrace option from the setup script to avoid printing the credentials in the log message
- Added code to RunCMD to print the out and err to standard out and err.