### PR TITLE
purge vms will continue to GET others though get of a VM fails

### DIFF
--- a/cmd/purge/vms/vms.go
+++ b/cmd/purge/vms/vms.go
@@ -68,7 +68,8 @@ pvsadm purge --help for information
 		for _, instance := range instances {
 			ins, err := pvmclient.InstanceClient.Get(*instance.PvmInstanceID)
 			if err != nil {
-				return fmt.Errorf("failed to get the instance: %v", err)
+				klog.Infof("Error occurred while getting the vm %s", err)
+				continue
 			}
 			var ipAddrsPrivate, ipAddrsPublic []string
 			for _, ip := range ins.Networks {


### PR DESCRIPTION
Currently, purge vms is returning error even if GET of one of the VM fails.
This PR will make the purge call continue to GETTING other VM s even if GET of any VM fails.

The existing `--ignore-errors` flag enables the DELETE call to proceed ahead even on failure of DELETE of any VM. Hence not modifying anything in delete section of the code.

Fixes: https://github.com/ppc64le-cloud/pvsadm/issues/78