### PR TITLE
Add optional cos-instance-name parameter for image import

### DIFF
--- a/cmd/image/import/import.go
+++ b/cmd/image/import/import.go
@@ -101,7 +101,11 @@ pvsadm image import -n upstream-core-lon04 -b <BUCKETNAME> --object rhel-83-1003
 			return err
 		}
 
-		instances, _, err := resourceController.ResourceControllerV2.ListResourceInstances(resourceController.ResourceControllerV2.NewListResourceInstancesOptions().SetType("service_instance"))
+		serviceListOptions := resourceController.ResourceControllerV2.NewListResourceInstancesOptions().SetType("service_instance")
+		if opt.COSInstanceName != "" {
+			serviceListOptions.SetName(opt.COSInstanceName)
+		}
+		instances, _, err := resourceController.ResourceControllerV2.ListResourceInstances(serviceListOptions)
 		if err != nil {
 			return err
 		}
@@ -239,6 +243,7 @@ func init() {
 	Cmd.Flags().StringVarP(&pkg.ImageCMDOptions.InstanceName, "pvs-instance-name", "n", "", "PowerVS Instance name.")
 	Cmd.Flags().StringVarP(&pkg.ImageCMDOptions.InstanceID, "pvs-instance-id", "i", "", "PowerVS Instance ID.")
 	Cmd.Flags().StringVarP(&pkg.ImageCMDOptions.BucketName, "bucket", "b", "", "Cloud Object Storage bucket name.")
+	Cmd.Flags().StringVarP(&pkg.ImageCMDOptions.COSInstanceName, "cos-instance-name", "s", "", "Cloud Object Storage instance name.")
 	Cmd.Flags().StringVarP(&pkg.ImageCMDOptions.Region, "bucket-region", "r", "", "Cloud Object Storage bucket location.")
 	Cmd.Flags().StringVarP(&pkg.ImageCMDOptions.ImageFilename, "object", "o", "", "Cloud Object Storage object name.")
 	Cmd.Flags().StringVar(&pkg.ImageCMDOptions.AccessKey, "accesskey", "", "Cloud Object Storage HMAC access key.")

--- a/pkg/client/s3client.go
+++ b/pkg/client/s3client.go
@@ -50,6 +50,7 @@ func NewS3Client(c *Client, instanceName, region string) (s3client *S3Client, er
 	var instanceID string
 	svcs, err := c.ResourceClient.ListInstances(controllerv2.ServiceInstanceQuery{
 		Type: "service_instance",
+		Name: instanceName,
 	})
 	if err != nil {
 		return s3client, fmt.Errorf("failed to list the resource instances: %v", err)

--- a/pkg/options.go
+++ b/pkg/options.go
@@ -58,6 +58,7 @@ type imageCMDOptions struct {
 	ServicePlan  string
 	ObjectName   string
 	//import options
+	COSInstanceName string
 	ImageFilename   string
 	AccessKey       string
 	SecretKey       string


### PR DESCRIPTION
Allow the COS instance name to be optionally specified on image
import. This can be used to overcome pagination issues during
Cloud Object Storage name lookup when more than 100 service
instances exist in an account.

Fixes: #120