### PR TITLE
Adding explicit steps for growing partitions

### DIFF
--- a/cmd/image/qcow2ova/prep/templates.go
+++ b/cmd/image/qcow2ova/prep/templates.go
@@ -135,6 +135,30 @@ cloud_final_modules:
  - final-message
  - power-state-change
  - reset_rmc
+
+ ### Explicit steps for growing partitions, since
+ ### growpart is failing on DM devices by default
+ ### Ref: https://bugs.launchpad.net/cloud-init/+bug/1556260
+ write_files:
+ - path: /tmp/update-disks.sh
+   permissions: 0744
+   owner: root
+   content: |
+      #!/usr/bin/env bash
+      set -e
+      for i in /dev/sd[a-z]; do
+        partprobe $i || true
+        growpart $i 2 || true
+      done
+      for i in /dev/mapper/mpath[a-z]; do
+        partprobe $i || true
+        growpart $i 2 || true
+      done
+
+runcmd:
+ - bash /tmp/update-disks.sh
+ - xfs_growfs -d /
+
 ### ^^^ Change 2: Recommendation from PowerVC
 
 system_info:

--- a/cmd/image/qcow2ova/qcow2ova.go
+++ b/cmd/image/qcow2ova/qcow2ova.go
@@ -246,7 +246,7 @@ func init() {
 	Cmd.Flags().StringVar(&pkg.ImageCMDOptions.ImageName, "image-name", "", "Name of the resultant OVA image")
 	Cmd.Flags().StringVar(&pkg.ImageCMDOptions.ImageURL, "image-url", "", "URL or absolute local file path to the <QCOW2>.gz image")
 	Cmd.Flags().StringVar(&pkg.ImageCMDOptions.ImageDist, "image-dist", "", "Image Distribution(supported: rhel, centos, coreos)")
-	Cmd.Flags().Uint64Var(&pkg.ImageCMDOptions.ImageSize, "image-size", 3, "Size (in GB) of the resultant OVA image")
+	Cmd.Flags().Uint64Var(&pkg.ImageCMDOptions.ImageSize, "image-size", 8, "Size (in GB) of the resultant OVA image")
 	Cmd.Flags().Int64Var(&pkg.ImageCMDOptions.TargetDiskSize, "target-disk-size", 120, "Size (in GB) of the target disk volume where OVA will be copied")
 	Cmd.Flags().StringVar(&pkg.ImageCMDOptions.RHNUser, "rhn-user", "", "RedHat Subscription username. Required when Image distribution is rhel")
 	Cmd.Flags().StringVar(&pkg.ImageCMDOptions.RHNPassword, "rhn-password", "", "RedHat Subscription password. Required when Image distribution is rhel")


### PR DESCRIPTION
By default growpart is failing for dm devices ; this patch is a workaround for fixing it.

```
2021-05-11 08:42:46,966 - util.py[DEBUG]: resize_devices took 0.013 seconds
2021-05-11 08:42:46,966 - cc_growpart.py[DEBUG]: '/' SKIPPED: device_part_info(/dev/mapper/mpathb2) failed: /dev/mapper/mpathb2 not a partition
2021-05-11 08:42:46,966 - handlers.py[DEBUG]: finish: init-local/config-growpart: SUCCESS: config-growpart ran successfully
2021-05-11 08:42:46,966 - stages.py[DEBUG]: Running module resizefs (<module 'cloudinit.config.cc_resizefs' from '/usr/lib/python3.6/site-packages/cloudinit/config/cc_resizefs.py'>) with frequency always
2021-05-11 08:42:46,967 - handlers.py[DEBUG]: start: init-local/config-resizefs: running config-resizefs with frequency always
``` 