### PR TITLE
Added pvsadm tool version in ova bundle

### DIFF
--- a/cmd/image/image.go
+++ b/cmd/image/image.go
@@ -16,6 +16,7 @@ package image
 
 import (
 	_import "github.com/ppc64le-cloud/pvsadm/cmd/image/import"
+	"github.com/ppc64le-cloud/pvsadm/cmd/image/info"
 	"github.com/ppc64le-cloud/pvsadm/cmd/image/qcow2ova"
 	"github.com/ppc64le-cloud/pvsadm/cmd/image/sync"
 	"github.com/ppc64le-cloud/pvsadm/cmd/image/upload"
@@ -33,4 +34,5 @@ func init() {
 	Cmd.AddCommand(qcow2ova.Cmd)
 	Cmd.AddCommand(upload.Cmd)
 	Cmd.AddCommand(sync.Cmd)
+	Cmd.AddCommand(info.Cmd)
 }

--- a/cmd/image/info/info.go
+++ b/cmd/image/info/info.go
@@ -1,0 +1,198 @@
+// Copyright 2022 IBM Corp
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package info
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/ppc64le-cloud/pvsadm/pkg"
+	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
+)
+
+// gunzipIt the source file to target
+func gunzipIt(src, dest string) error {
+	reader, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+
+	archive, err := gzip.NewReader(reader)
+	if err != nil {
+		return err
+	}
+	defer archive.Close()
+
+	writer, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer writer.Close()
+
+	_, err = io.Copy(writer, archive)
+	return err
+}
+
+// isGzip returns if file is in gzip format
+func isGzip(source string) (bool, error) {
+	file, err := os.Open(source)
+	if err != nil {
+		return false, err
+	}
+	defer file.Close()
+
+	buff := make([]byte, 512)
+	_, err = file.Read(buff)
+	if err != nil {
+		return false, err
+	}
+
+	if filetype := http.DetectContentType(buff); filetype == "application/x-gzip" {
+		return true, nil
+	} else {
+		return false, nil
+	}
+}
+
+// Extract specific file from the tar file
+func Untar(tarball, target, filename string) error {
+	reader, err := os.Open(tarball)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+	tarReader := tar.NewReader(reader)
+
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+
+		if header.Name != filename {
+			continue
+		}
+		path := filepath.Join(target, header.Name)
+		info := header.FileInfo()
+		if info.IsDir() {
+			if err = os.MkdirAll(path, info.Mode()); err != nil {
+				return err
+			}
+			continue
+		}
+
+		file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, info.Mode())
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		_, err = io.Copy(file, tarReader)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+var Cmd = &cobra.Command{
+	Use:   "info",
+	Short: "Provide info about the image",
+	Long: `Provide info about the image
+pvsadm image info --help for information
+
+
+Examples:
+
+# To get the pvsadm tool version by specifying the image
+pvsadm image info --file rhcos-46-12152021.ova.gz
+
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		opt := pkg.ImageCMDOptions
+		var ova string
+		ovaImgDir, err := os.MkdirTemp(opt.TemDir, "ova-img-dir")
+		if err != nil {
+			return err
+		}
+
+		defer os.RemoveAll(ovaImgDir)
+
+		//Check if the image is in gzip format and unzip it.
+		checkGzip, err := isGzip(opt.Filename)
+		if err != nil {
+			return fmt.Errorf("failed to detect the image filetype: %v", err)
+		}
+		if checkGzip {
+			klog.Infof("Image %s is in gzip format, extracting it", opt.Filename)
+			ova = filepath.Join(ovaImgDir, "image.ova")
+			err = gunzipIt(opt.Filename, ova)
+			if err != nil {
+				return err
+			}
+			klog.Infof("Extract complete")
+		} else {
+			ova = opt.Filename
+		}
+
+		//Extract the ovf file
+		err = Untar(ova, ovaImgDir, "coreos.ovf")
+		if err != nil {
+			return err
+		}
+		filename := filepath.Join(ovaImgDir, "coreos.ovf")
+
+		type Ovf struct {
+			Pvsadmversionsection struct {
+				Info        string `xml:"Info"`
+				BuildNumber string `xml:"BuildNumber"`
+			} `xml:"pvsadmversionsection"`
+		}
+
+		xmlFile, err := os.Open(filename)
+		if err != nil {
+			return err
+		}
+		defer xmlFile.Close()
+		var version Ovf
+		byteValue, _ := ioutil.ReadAll(xmlFile)
+		xml.Unmarshal(byteValue, &version)
+		toolversion := version.Pvsadmversionsection.BuildNumber
+		if toolversion == "" {
+			return fmt.Errorf("unable to find the pvsadm tool version")
+		}
+		klog.Infof("Pvsadm tool version used for creating this image: %+v", toolversion)
+		return nil
+	},
+}
+
+// Init method
+func init() {
+	Cmd.Flags().StringVarP(&pkg.ImageCMDOptions.Filename, "file", "f", "", "The PATH to the image")
+	Cmd.Flags().StringVarP(&pkg.ImageCMDOptions.TemDir, "temp-dir", "t", os.TempDir(), "Scratch space to use for OVA extraction")
+	_ = Cmd.MarkFlagRequired("file")
+	Cmd.Flags().SortFlags = false
+}

--- a/cmd/image/info/info.go
+++ b/cmd/image/info/info.go
@@ -15,120 +15,16 @@
 package info
 
 import (
-	"archive/tar"
-	"compress/gzip"
 	"encoding/xml"
 	"fmt"
-	"io"
 	"io/ioutil"
-	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 
-	"github.com/ppc64le-cloud/pvsadm/pkg"
+	"github.com/ppc64le-cloud/pvsadm/pkg/utils"
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 )
-
-// gunzipIt the source file to target
-func gunzipIt(src, dest string) error {
-	reader, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer reader.Close()
-
-	archive, err := gzip.NewReader(reader)
-	if err != nil {
-		return err
-	}
-	defer archive.Close()
-
-	writer, err := os.Create(dest)
-	if err != nil {
-		return err
-	}
-	defer writer.Close()
-
-	_, err = io.Copy(writer, archive)
-	return err
-}
-
-// isGzip returns if file is in gzip format
-func isGzip(source string) (bool, error) {
-	file, err := os.Open(source)
-	if err != nil {
-		return false, err
-	}
-	defer file.Close()
-
-	buff := make([]byte, 512)
-	_, err = file.Read(buff)
-	if err != nil {
-		return false, err
-	}
-
-	if filetype := http.DetectContentType(buff); filetype == "application/x-gzip" {
-		return true, nil
-	} else {
-		return false, nil
-	}
-}
-
-func SanitizeExtractPath(filePath string, destination string) error {
-	destpath := filepath.Join(destination, filePath)
-	if !strings.HasPrefix(destpath, filepath.Clean(destination)+string(os.PathSeparator)) {
-		return fmt.Errorf("%s: illegal file path", filePath)
-	}
-	return nil
-}
-
-// Extract specific file from the tar file
-func Untar(tarball, target, filename string) error {
-	reader, err := os.Open(tarball)
-	if err != nil {
-		return err
-	}
-	defer reader.Close()
-	tarReader := tar.NewReader(reader)
-
-	for {
-		header, err := tarReader.Next()
-		if err == io.EOF {
-			break
-		} else if err != nil {
-			return err
-		}
-
-		if header.Name != filename {
-			continue
-		}
-		err = SanitizeExtractPath(header.Name, target)
-		if err != nil {
-			return err
-		}
-		path := filepath.Join(target, header.Name)
-		info := header.FileInfo()
-		if info.IsDir() {
-			if err = os.MkdirAll(path, info.Mode()); err != nil {
-				return err
-			}
-			continue
-		}
-
-		file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, info.Mode())
-		if err != nil {
-			return err
-		}
-		defer file.Close()
-		_, err = io.Copy(file, tarReader)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
 
 var Cmd = &cobra.Command{
 	Use:   "info",
@@ -145,9 +41,9 @@ pvsadm image info --file rhcos-46-12152021.ova.gz
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
-		opt := pkg.ImageCMDOptions
+		fileName := args[0]
 		var ova string
-		ovaImgDir, err := os.MkdirTemp(opt.TemDir, "ova-img-dir")
+		ovaImgDir, err := os.MkdirTemp(os.TempDir(), "ova-img-dir")
 		if err != nil {
 			return err
 		}
@@ -155,24 +51,24 @@ pvsadm image info --file rhcos-46-12152021.ova.gz
 		defer os.RemoveAll(ovaImgDir)
 
 		//Check if the image is in gzip format and unzip it.
-		checkGzip, err := isGzip(opt.Filename)
+		checkGzip, err := utils.IsGzip(fileName)
 		if err != nil {
 			return fmt.Errorf("failed to detect the image filetype: %v", err)
 		}
 		if checkGzip {
-			klog.Infof("Image %s is in gzip format, extracting it", opt.Filename)
+			klog.Infof("Image %s is in gzip format, extracting it", fileName)
 			ova = filepath.Join(ovaImgDir, "image.ova")
-			err = gunzipIt(opt.Filename, ova)
+			err = utils.GunzipIt(fileName, ova)
 			if err != nil {
 				return err
 			}
 			klog.Infof("Extract complete")
 		} else {
-			ova = opt.Filename
+			ova = fileName
 		}
 
 		//Extract the ovf file
-		err = Untar(ova, ovaImgDir, "coreos.ovf")
+		err = utils.Untar(ova, ovaImgDir, "*.ovf")
 		if err != nil {
 			return err
 		}
@@ -191,21 +87,20 @@ pvsadm image info --file rhcos-46-12152021.ova.gz
 		}
 		defer xmlFile.Close()
 		var version Ovf
-		byteValue, _ := ioutil.ReadAll(xmlFile)
-		xml.Unmarshal(byteValue, &version)
+		byteValue, err := ioutil.ReadAll(xmlFile)
+		if err != nil {
+			return err
+		}
+		err = xml.Unmarshal(byteValue, &version)
+		if err != nil {
+			return err
+		}
 		toolversion := version.Pvsadmversionsection.BuildNumber
 		if toolversion == "" {
-			return fmt.Errorf("unable to find the pvsadm tool version")
+			klog.Warning("unable to find the pvsadm tool version")
+			return nil
 		}
 		klog.Infof("Pvsadm tool version used for creating this image: %+v", toolversion)
 		return nil
 	},
-}
-
-// Init method
-func init() {
-	Cmd.Flags().StringVarP(&pkg.ImageCMDOptions.Filename, "file", "f", "", "The PATH to the image")
-	Cmd.Flags().StringVarP(&pkg.ImageCMDOptions.TemDir, "temp-dir", "t", os.TempDir(), "Scratch space to use for OVA extraction")
-	_ = Cmd.MarkFlagRequired("file")
-	Cmd.Flags().SortFlags = false
 }

--- a/cmd/image/info/info.go
+++ b/cmd/image/info/info.go
@@ -36,7 +36,7 @@ pvsadm image info --help for information
 Examples:
 
 # To get the pvsadm tool version by specifying the image
-pvsadm image info --file rhcos-46-12152021.ova.gz
+pvsadm image info rhcos-46-12152021.ova.gz
 
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -72,7 +72,12 @@ pvsadm image info --file rhcos-46-12152021.ova.gz
 		if err != nil {
 			return err
 		}
-		filename := filepath.Join(ovaImgDir, "coreos.ovf")
+		ovfFilePath := ovaImgDir + "/*.ovf"
+		matches, err := filepath.Glob(ovfFilePath)
+		if err != nil {
+			return err
+		}
+		filename := matches[0]
 
 		type Ovf struct {
 			Pvsadmversionsection struct {

--- a/cmd/image/info/info.go
+++ b/cmd/image/info/info.go
@@ -32,14 +32,16 @@ var Cmd = &cobra.Command{
 	Long: `Provide info about the image
 pvsadm image info --help for information
 
-
 Examples:
-
 # To get the pvsadm tool version by specifying the image
 pvsadm image info rhcos-46-12152021.ova.gz
 
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if len(args) == 0 {
+			return fmt.Errorf("Image filepath is required")
+		}
 
 		fileName := args[0]
 		var ova string
@@ -76,6 +78,9 @@ pvsadm image info rhcos-46-12152021.ova.gz
 		matches, err := filepath.Glob(ovfFilePath)
 		if err != nil {
 			return err
+		}
+		if len(matches) == 0 {
+			return fmt.Errorf("Unable to extract the ovf file")
 		}
 		filename := matches[0]
 

--- a/cmd/image/info/info.go
+++ b/cmd/image/info/info.go
@@ -80,7 +80,7 @@ pvsadm image info rhcos-46-12152021.ova.gz
 			return err
 		}
 		if len(matches) == 0 {
-			return fmt.Errorf("Unable to extract the ovf file")
+			return fmt.Errorf(".ovf file is not found in %s image", fileName)
 		}
 		filename := matches[0]
 

--- a/cmd/image/qcow2ova/ova/ova.go
+++ b/cmd/image/qcow2ova/ova/ova.go
@@ -44,7 +44,7 @@ func Render(imageName, volumeName string, srcVolumeSize int64, targetDiskSize in
 	//Disk Size should be in bytes
 	PvsadmVersion := version.Get()
 	o := OVA{
-		imageName, volumeName, srcVolumeSize, targetDiskSize * 1073741824, PvsadmVersion,
+		imageName, volumeName, srcVolumeSize, targetDiskSize * 1073741824, version.Get(),
 	}
 
 	var wr bytes.Buffer

--- a/cmd/image/qcow2ova/ova/ova.go
+++ b/cmd/image/qcow2ova/ova/ova.go
@@ -42,7 +42,6 @@ type OVA struct {
 // and size
 func Render(imageName, volumeName string, srcVolumeSize int64, targetDiskSize int64) (string, error) {
 	//Disk Size should be in bytes
-	PvsadmVersion := version.Get()
 	o := OVA{
 		imageName, volumeName, srcVolumeSize, targetDiskSize * 1073741824, version.Get(),
 	}

--- a/cmd/image/qcow2ova/ova/ova.go
+++ b/cmd/image/qcow2ova/ova/ova.go
@@ -22,6 +22,8 @@ import (
 	"os"
 	"path/filepath"
 	"text/template"
+
+	"github.com/ppc64le-cloud/pvsadm/pkg/version"
 )
 
 const (
@@ -33,15 +35,18 @@ type OVA struct {
 	ImageName, VolumeName string
 	SrcVolumeSize         int64
 	TargetDiskSize        int64
+	PvsadmVersion         string
 }
 
 // Render will generate the OVA spec from the template with all the required information like image name, volume name
 // and size
 func Render(imageName, volumeName string, srcVolumeSize int64, targetDiskSize int64) (string, error) {
 	//Disk Size should be in bytes
+	PvsadmVersion := version.Get()
 	o := OVA{
-		imageName, volumeName, srcVolumeSize, targetDiskSize * 1073741824,
+		imageName, volumeName, srcVolumeSize, targetDiskSize * 1073741824, PvsadmVersion,
 	}
+
 	var wr bytes.Buffer
 	t := template.Must(template.New("ova").Parse(ovfTemplate))
 	err := t.Execute(&wr, o)

--- a/cmd/image/qcow2ova/ova/template.go
+++ b/cmd/image/qcow2ova/ova/template.go
@@ -56,4 +56,8 @@ var ovfTemplate = `<?xml version="1.0" encoding="UTF-8"?>
     <ovf:Info/>
     <ovf:Name>{{.ImageName}}</ovf:Name>
   </ovf:VirtualSystemCollection>
+  <ovf:pvsadmversionsection ovf:required="false">
+    <ovf:Info>Specifies pvsadm version </ovf:Info>
+    <ovf:BuildNumber>{{.PvsadmVersion}}</ovf:BuildNumber>
+  </ovf:pvsadmversionsection>
 </ovf:Envelope>`

--- a/cmd/image/qcow2ova/qcow2ova.go
+++ b/cmd/image/qcow2ova/qcow2ova.go
@@ -180,14 +180,14 @@ Examples:
 
 		var qcow2Img string
 
-		checkGzip, err := isGzip(image)
+		checkGzip, err := utils.IsGzip(image)
 		if err != nil {
 			return fmt.Errorf("failed to detect the image filetype: %v", err)
 		}
 		if checkGzip {
 			klog.Infof("Image %s is in gzip format, extracting it", image)
 			qcow2Img = filepath.Join(tmpDir, ova.VolName+".qcow2")
-			err = gunzipIt(image, qcow2Img)
+			err = utils.GunzipIt(image, qcow2Img)
 			if err != nil {
 				return err
 			}
@@ -234,7 +234,7 @@ Examples:
 
 		klog.Infof("Compressing an OVA file")
 		ovaGZfile := filepath.Join(cwd, opt.ImageName+".ova.gz")
-		err = gzipIt(ovafile, ovaGZfile)
+		err = utils.GzipIt(ovafile, ovaGZfile)
 		if err != nil {
 			return err
 		}

--- a/pkg/options.go
+++ b/pkg/options.go
@@ -73,7 +73,4 @@ type imageCMDOptions struct {
 	WatchTimeout    time.Duration
 	//sync options
 	SpecYAML string
-	//info options
-	Filename string
-	TemDir   string
 }

--- a/pkg/options.go
+++ b/pkg/options.go
@@ -73,4 +73,7 @@ type imageCMDOptions struct {
 	WatchTimeout    time.Duration
 	//sync options
 	SpecYAML string
+	//info options
+	Filename string
+	TemDir   string
 }

--- a/pkg/utils/gzip.go
+++ b/pkg/utils/gzip.go
@@ -1,4 +1,4 @@
-// Copyright 2021 IBM Corp
+// Copyright 2022 IBM Corp
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package qcow2ova
+package utils
 
 import (
 	"io"
@@ -23,8 +23,8 @@ import (
 	gzip "github.com/klauspost/pgzip"
 )
 
-// gzipIt compresses the source file to dest
-func gzipIt(src, dest string) error {
+// GzipIt compresses the source file to dest
+func GzipIt(src, dest string) error {
 	reader, err := os.Open(src)
 	if err != nil {
 		return err
@@ -45,8 +45,8 @@ func gzipIt(src, dest string) error {
 	return err
 }
 
-// gunzipIt the source file to target
-func gunzipIt(src, dest string) error {
+// GunzipIt the source file to target
+func GunzipIt(src, dest string) error {
 	reader, err := os.Open(src)
 	if err != nil {
 		return err
@@ -69,8 +69,8 @@ func gunzipIt(src, dest string) error {
 	return err
 }
 
-// isGzip returns if file is in gzip format
-func isGzip(source string) (bool, error) {
+// IsGzip returns if file is in gzip format
+func IsGzip(source string) (bool, error) {
 	file, err := os.Open(source)
 	if err != nil {
 		return false, err

--- a/pkg/utils/tar.go
+++ b/pkg/utils/tar.go
@@ -54,8 +54,6 @@ func Untar(tarball, target, filename string) error {
 		if !matched {
 			continue
 		}
-
-		fmt.Printf("Filename: %+v\n", header)
 		filename = header.Name
 		err = SanitizeExtractPath(header.Name, target)
 		if err != nil {

--- a/pkg/utils/tar.go
+++ b/pkg/utils/tar.go
@@ -1,0 +1,84 @@
+// Copyright 2022 IBM Corp
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func SanitizeExtractPath(filePath string, destination string) error {
+	destpath := filepath.Join(destination, filePath)
+	if !strings.HasPrefix(destpath, filepath.Clean(destination)+string(os.PathSeparator)) {
+		return fmt.Errorf("%s: illegal file path", filePath)
+	}
+	return nil
+}
+
+// Extract specific file from the tar file
+func Untar(tarball, target, filename string) error {
+	reader, err := os.Open(tarball)
+	if err != nil {
+		return err
+	}
+	defer reader.Close()
+	tarReader := tar.NewReader(reader)
+
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+		matched, err := filepath.Match(filename, header.Name)
+		if err != nil {
+			return err
+		}
+		if !matched {
+			continue
+		}
+
+		fmt.Printf("Filename: %+v\n", header)
+		filename = header.Name
+		err = SanitizeExtractPath(header.Name, target)
+		if err != nil {
+			return err
+		}
+		path := filepath.Join(target, header.Name)
+		info := header.FileInfo()
+		if info.IsDir() {
+			if err = os.MkdirAll(path, info.Mode()); err != nil {
+				return err
+			}
+			continue
+		}
+
+		file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, info.Mode())
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		_, err = io.Copy(file, tarReader)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/utils/tar_test.go
+++ b/pkg/utils/tar_test.go
@@ -1,0 +1,52 @@
+// Copyright 2022 IBM Corp
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"testing"
+)
+
+func TestSanitizeExtractPath(t *testing.T) {
+	type args struct {
+		filePath    string
+		destination string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			"with proper filepath",
+			args{"/test", "new"},
+			false,
+		},
+		{
+			"With improper filepath",
+			args{"../test", "new"},
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizeExtractPath(tt.args.filePath, tt.args.destination)
+			if (got != nil) != tt.wantErr {
+				t.Errorf("SanitizeExtractPath() got  %v, wantErr %v", got, tt.wantErr)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
Added the pvsadm tool version in the ova spec.

Added a new section for pvsadm version (pvsadmversionsection) in the ovf template.

Added a new command `pvsadm image info <image name>` to get the pvsadm tool version from the ova spec
