### PR TITLE
Add dhcpserver command

### DIFF
--- a/cmd/dhcpserver/cmd.go
+++ b/cmd/dhcpserver/cmd.go
@@ -26,9 +26,6 @@ var Cmd = &cobra.Command{
 	Use:   "dhcpserver",
 	Short: "dhcpserver command",
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		if pkg.Options.InstanceID == "" {
-			return fmt.Errorf("--instance-id is required")
-		}
 		if pkg.Options.APIKey == "" {
 			return fmt.Errorf("api-key can't be empty, pass the token via --api-key or set IBMCLOUD_API_KEY environment variable")
 		}
@@ -46,4 +43,5 @@ func init() {
 	Cmd.AddCommand(deleteCmd)
 
 	Cmd.PersistentFlags().StringVarP(&pkg.Options.InstanceID, "instance-id", "i", "", "Instance ID of the PowerVS instance")
+	_ = Cmd.MarkPersistentFlagRequired("instance-id")
 }

--- a/cmd/dhcpserver/cmd.go
+++ b/cmd/dhcpserver/cmd.go
@@ -1,0 +1,49 @@
+// Copyright 2022 IBM Corp
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dhcpserver
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ppc64le-cloud/pvsadm/pkg"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "dhcpserver",
+	Short: "dhcpserver command",
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if pkg.Options.InstanceID == "" {
+			return fmt.Errorf("--instance-id is required")
+		}
+		if pkg.Options.APIKey == "" {
+			return fmt.Errorf("api-key can't be empty, pass the token via --api-key or set IBMCLOUD_API_KEY environment variable")
+		}
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return nil
+	},
+}
+
+func init() {
+	Cmd.AddCommand(createCmd)
+	Cmd.AddCommand(listCmd)
+	Cmd.AddCommand(getCmd)
+	Cmd.AddCommand(deleteCmd)
+
+	Cmd.PersistentFlags().StringVarP(&pkg.Options.InstanceID, "instance-id", "i", "", "Instance ID of the PowerVS instance")
+}

--- a/cmd/dhcpserver/create.go
+++ b/cmd/dhcpserver/create.go
@@ -1,0 +1,67 @@
+// Copyright 2022 IBM Corp
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dhcpserver
+
+import (
+	"fmt"
+
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
+
+	"github.com/IBM-Cloud/power-go-client/power/models"
+	"github.com/ppc64le-cloud/pvsadm/pkg"
+	"github.com/ppc64le-cloud/pvsadm/pkg/client"
+)
+
+var (
+	network, ipaddress, description, cloudConnectionID string
+)
+
+var createCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create DHCP Server",
+	Long:  `Create DHCP Server`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		opt := pkg.Options
+
+		c, err := client.NewClientWithEnv(opt.APIKey, opt.Environment, opt.Debug)
+		if err != nil {
+			klog.Errorf("failed to create a session with IBM cloud: %v", err)
+			return err
+		}
+
+		pvmclient, err := client.NewPVMClientWithEnv(c, opt.InstanceID, opt.InstanceName, opt.Environment)
+		if err != nil {
+			return err
+		}
+
+		body := &models.DHCPServerCreate{}
+		if cloudConnectionID != "" {
+			body.CloudConnectionID = core.StringPtr(cloudConnectionID)
+		}
+		_, err = pvmclient.DHCPClient.Create(body)
+		if err != nil {
+			return fmt.Errorf("failed to create a dhcpserver, err: %v", err)
+		}
+
+		klog.Infof("Successfully created a DHCP server")
+		return nil
+	},
+}
+
+func init() {
+	createCmd.Flags().StringVar(&cloudConnectionID, "cloud-connection-id", "", "Instance ID of the Cloud connection")
+}

--- a/cmd/dhcpserver/create.go
+++ b/cmd/dhcpserver/create.go
@@ -16,8 +16,8 @@ package dhcpserver
 
 import (
 	"fmt"
-
 	"github.com/IBM/go-sdk-core/v5/core"
+
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
 
@@ -27,7 +27,8 @@ import (
 )
 
 var (
-	network, ipaddress, description, cloudConnectionID string
+	cidr, dns, name, cloudConnectionID string
+	snat                               bool
 )
 
 var createCmd = &cobra.Command{
@@ -48,9 +49,20 @@ var createCmd = &cobra.Command{
 			return err
 		}
 
-		body := &models.DHCPServerCreate{}
+		body := &models.DHCPServerCreate{
+			SnatEnabled: core.BoolPtr(snat),
+		}
+		if cidr != "" {
+			body.Cidr = core.StringPtr(cidr)
+		}
 		if cloudConnectionID != "" {
 			body.CloudConnectionID = core.StringPtr(cloudConnectionID)
+		}
+		if dns != "" {
+			body.DNSServer = core.StringPtr(dns)
+		}
+		if name != "" {
+			body.Name = core.StringPtr(name)
 		}
 		_, err = pvmclient.DHCPClient.Create(body)
 		if err != nil {
@@ -63,5 +75,9 @@ var createCmd = &cobra.Command{
 }
 
 func init() {
+	createCmd.Flags().StringVar(&cidr, "cidr", "", "CIDR")
 	createCmd.Flags().StringVar(&cloudConnectionID, "cloud-connection-id", "", "Instance ID of the Cloud connection")
+	createCmd.Flags().StringVar(&dns, "dns-server", "", "DNS Server")
+	createCmd.Flags().StringVar(&name, "name", "", "Name")
+	createCmd.Flags().BoolVar(&snat, "snat", true, "SNAT Enabled")
 }

--- a/cmd/dhcpserver/delete.go
+++ b/cmd/dhcpserver/delete.go
@@ -1,0 +1,58 @@
+// Copyright 2022 IBM Corp
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dhcpserver
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
+
+	"github.com/ppc64le-cloud/pvsadm/pkg"
+	"github.com/ppc64le-cloud/pvsadm/pkg/client"
+)
+
+var dhcp string
+var deleteCmd = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete DHCP Server",
+	Long:  `Delete DHCP Server`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		opt := pkg.Options
+
+		c, err := client.NewClientWithEnv(opt.APIKey, opt.Environment, opt.Debug)
+		if err != nil {
+			klog.Errorf("failed to create a session with IBM cloud: %v", err)
+			return err
+		}
+
+		pvmclient, err := client.NewPVMClientWithEnv(c, opt.InstanceID, opt.InstanceName, opt.Environment)
+		if err != nil {
+			return err
+		}
+
+		err = pvmclient.DHCPClient.Delete(dhcp)
+		if err != nil {
+			return fmt.Errorf("failed to delete a dhcpserver, err: %v", err)
+		}
+
+		klog.Infof("Successfully Deleted a DHCP server")
+		return nil
+	},
+}
+
+func init() {
+	deleteCmd.Flags().StringVar(&dhcp, "id", "", "Instance ID of the DHCP server to be deleted")
+}

--- a/cmd/dhcpserver/delete.go
+++ b/cmd/dhcpserver/delete.go
@@ -55,4 +55,5 @@ var deleteCmd = &cobra.Command{
 
 func init() {
 	deleteCmd.Flags().StringVar(&dhcp, "id", "", "Instance ID of the DHCP server to be deleted")
+	_ = deleteCmd.MarkPersistentFlagRequired("id")
 }

--- a/cmd/dhcpserver/get.go
+++ b/cmd/dhcpserver/get.go
@@ -1,0 +1,63 @@
+// Copyright 2022 IBM Corp
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dhcpserver
+
+import (
+	"fmt"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
+
+	"github.com/ppc64le-cloud/pvsadm/pkg"
+	"github.com/ppc64le-cloud/pvsadm/pkg/client"
+)
+
+var (
+	id string
+)
+
+var getCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get DHCP Server",
+	Long:  `Get DHCP Server`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		opt := pkg.Options
+
+		c, err := client.NewClientWithEnv(opt.APIKey, opt.Environment, opt.Debug)
+		if err != nil {
+			klog.Errorf("failed to create a session with IBM cloud: %v", err)
+			return err
+		}
+
+		pvmclient, err := client.NewPVMClientWithEnv(c, opt.InstanceID, opt.InstanceName, opt.Environment)
+		if err != nil {
+			return err
+		}
+
+		servers, err := pvmclient.DHCPClient.Get(id)
+		if err != nil {
+			return fmt.Errorf("failed to get a dhcpserver, err: %v", err)
+		}
+
+		spew.Dump(servers)
+		return nil
+	},
+}
+
+func init() {
+	getCmd.Flags().StringVar(&id, "id", "", "Instance ID of the Cloud connection")
+	_ = getCmd.MarkFlagRequired("id")
+}

--- a/cmd/dhcpserver/list.go
+++ b/cmd/dhcpserver/list.go
@@ -1,0 +1,61 @@
+// Copyright 2022 IBM Corp
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dhcpserver
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
+
+	"github.com/ppc64le-cloud/pvsadm/pkg"
+	"github.com/ppc64le-cloud/pvsadm/pkg/client"
+	"github.com/ppc64le-cloud/pvsadm/pkg/utils"
+)
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Get PowerVS DHCP servers",
+	Long:  `Get PowerVS DHCP servers`,
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if pkg.Options.InstanceID == "" && pkg.Options.InstanceName == "" {
+			return fmt.Errorf("--instance-id or --instance-name required")
+		}
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		opt := pkg.Options
+
+		c, err := client.NewClientWithEnv(opt.APIKey, opt.Environment, opt.Debug)
+		if err != nil {
+			klog.Errorf("failed to create a session with IBM cloud: %v", err)
+			return err
+		}
+
+		pvmclient, err := client.NewPVMClientWithEnv(c, opt.InstanceID, opt.InstanceName, opt.Environment)
+		if err != nil {
+			return err
+		}
+
+		dhcpservers, err := pvmclient.DHCPClient.GetAll()
+		if err != nil {
+			return fmt.Errorf("failed to get the networks, err: %v", err)
+		}
+
+		table := utils.NewTable()
+		table.Render(dhcpservers, nil)
+		return nil
+	},
+}

--- a/cmd/dhcpserver/list.go
+++ b/cmd/dhcpserver/list.go
@@ -29,12 +29,6 @@ var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "Get PowerVS DHCP servers",
 	Long:  `Get PowerVS DHCP servers`,
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		if pkg.Options.InstanceID == "" && pkg.Options.InstanceName == "" {
-			return fmt.Errorf("--instance-id or --instance-name required")
-		}
-		return nil
-	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		opt := pkg.Options
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ppc64le-cloud/pvsadm/cmd/create"
 	deletecmd "github.com/ppc64le-cloud/pvsadm/cmd/delete"
 	"github.com/ppc64le-cloud/pvsadm/cmd/dhcp-sync"
+	"github.com/ppc64le-cloud/pvsadm/cmd/dhcpserver"
 	"github.com/ppc64le-cloud/pvsadm/cmd/get"
 	"github.com/ppc64le-cloud/pvsadm/cmd/image"
 	"github.com/ppc64le-cloud/pvsadm/cmd/purge"
@@ -69,6 +70,7 @@ func init() {
 	rootCmd.AddCommand(create.Cmd)
 	rootCmd.AddCommand(deletecmd.Cmd)
 	rootCmd.AddCommand(dhcp.Cmd)
+	rootCmd.AddCommand(dhcpserver.Cmd)
 	rootCmd.PersistentFlags().StringVarP(&pkg.Options.APIKey, "api-key", "k", "", "IBMCLOUD API Key(env name: IBMCLOUD_API_KEY)")
 	rootCmd.PersistentFlags().StringVar(&pkg.Options.Environment, "env", client.DefaultEnv, "IBM Cloud Environments, supported are: ["+strings.Join(client.ListEnvironments(), ", ")+"]")
 	rootCmd.PersistentFlags().BoolVar(&pkg.Options.Debug, "debug", false, "Enable PowerVS debug option(ATTENTION: dev only option, may print sensitive data from APIs)")

--- a/pkg/client/dhcp/dhcp.go
+++ b/pkg/client/dhcp/dhcp.go
@@ -1,0 +1,54 @@
+// Copyright 2021 IBM Corp
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dhcp
+
+import (
+	"context"
+
+	"github.com/IBM-Cloud/power-go-client/clients/instance"
+	"github.com/IBM-Cloud/power-go-client/ibmpisession"
+	"github.com/IBM-Cloud/power-go-client/power/models"
+)
+
+type Client struct {
+	session    *ibmpisession.IBMPISession
+	client     *instance.IBMPIDhcpClient
+	instanceID string
+}
+
+func NewClient(sess *ibmpisession.IBMPISession, powerinstanceid string) *Client {
+	c := &Client{
+		session:    sess,
+		instanceID: powerinstanceid,
+	}
+	c.client = instance.NewIBMPIDhcpClient(context.Background(), sess, powerinstanceid)
+	return c
+}
+
+func (c *Client) Get(id string) (*models.DHCPServerDetail, error) {
+	return c.client.Get(id)
+}
+
+func (c *Client) GetAll() (models.DHCPServers, error) {
+	return c.client.GetAll()
+}
+
+func (c *Client) Create(body *models.DHCPServerCreate) (*models.DHCPServer, error) {
+	return c.client.Create(body)
+}
+
+func (c *Client) Delete(id string) error {
+	return c.client.Delete(id)
+}

--- a/pkg/client/pvmclient.go
+++ b/pkg/client/pvmclient.go
@@ -26,6 +26,7 @@ import (
 	utils "github.com/ppc64le-cloud/powervs-utils"
 
 	"github.com/ppc64le-cloud/pvsadm/pkg"
+	"github.com/ppc64le-cloud/pvsadm/pkg/client/dhcp"
 	"github.com/ppc64le-cloud/pvsadm/pkg/client/events"
 	"github.com/ppc64le-cloud/pvsadm/pkg/client/image"
 	"github.com/ppc64le-cloud/pvsadm/pkg/client/instance"
@@ -49,6 +50,7 @@ type PVMClient struct {
 	NetworkClient  *network.Client
 	EventsClient   *events.Client
 	KeyClient      *key.Client
+	DHCPClient     *dhcp.Client
 }
 
 func NewPVMClient(c *Client, instanceID, instanceName, ep string) (*PVMClient, error) {
@@ -107,5 +109,6 @@ func NewPVMClient(c *Client, instanceID, instanceName, ep string) (*PVMClient, e
 	pvmclient.NetworkClient = network.NewClient(pvmclient.PISession, instanceID)
 	pvmclient.EventsClient = events.NewClient(pvmclient.PISession, instanceID)
 	pvmclient.KeyClient = key.NewClient(pvmclient.PISession, instanceID)
+	pvmclient.DHCPClient = dhcp.NewClient(pvmclient.PISession, instanceID)
 	return pvmclient, nil
 }


### PR DESCRIPTION
This PR will add support for the dhcpserver command

```shell
% ./bin/pvsadm dhcpserver --help
dhcpserver command

Usage:
  pvsadm dhcpserver [flags]
  pvsadm dhcpserver [command]

Available Commands:
  create      Create DHCP Server
  delete      Delete DHCP Server
  get         Get DHCP Server
  list        Get PowerVS DHCP servers

Flags:
  -h, --help                 help for dhcpserver
  -i, --instance-id string   Instance ID of the PowerVS instance

Global Flags:
      --add_dir_header                   If true, adds the file directory to the header of the log messages
      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
  -k, --api-key string                   IBMCLOUD API Key(env name: IBMCLOUD_API_KEY)
      --audit-file string                Audit logs for the tool (default "pvsadm.log")
      --debug                            Enable PowerVS debug option(ATTENTION: dev only option, may print sensitive data from APIs)
      --env string                       IBM Cloud Environments, supported are: [test, prod] (default "prod")
      --log_backtrace_at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
      --log_dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
      --log_file string                  If non-empty, use this log file (no effect when -logtostderr=true)
      --log_file_max_size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
      --logtostderr                      log to standard error instead of files (default true)
      --one_output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
      --skip_headers                     If true, avoid header prefixes in the log messages
      --skip_log_headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
  -v, --v Level                          number for the log level verbosity
      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging

Use "pvsadm dhcpserver [command] --help" for more information about a command.

```