### PR TITLE
Updated different os ID for coreos images

### DIFF
--- a/cmd/image/qcow2ova/ova/ova.go
+++ b/cmd/image/qcow2ova/ova/ova.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"text/template"
 
+	"github.com/ppc64le-cloud/pvsadm/pkg"
 	"github.com/ppc64le-cloud/pvsadm/pkg/version"
 )
 
@@ -36,14 +37,21 @@ type OVA struct {
 	SrcVolumeSize         int64
 	TargetDiskSize        int64
 	PvsadmVersion         string
+	OsId                  string
 }
 
 // Render will generate the OVA spec from the template with all the required information like image name, volume name
 // and size
 func Render(imageName, volumeName string, srcVolumeSize int64, targetDiskSize int64) (string, error) {
 	//Disk Size should be in bytes
+
+	opt := pkg.ImageCMDOptions
+	osId := "79"
+	if opt.ImageDist == "coreos" {
+		osId = "80"
+	}
 	o := OVA{
-		imageName, volumeName, srcVolumeSize, targetDiskSize * 1073741824, version.Get(),
+		imageName, volumeName, srcVolumeSize, targetDiskSize * 1073741824, version.Get(), osId,
 	}
 
 	var wr bytes.Buffer

--- a/cmd/image/qcow2ova/ova/ova.go
+++ b/cmd/image/qcow2ova/ova/ova.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 	"text/template"
 
-	"github.com/ppc64le-cloud/pvsadm/pkg"
 	"github.com/ppc64le-cloud/pvsadm/pkg/version"
 )
 
@@ -42,12 +41,10 @@ type OVA struct {
 
 // Render will generate the OVA spec from the template with all the required information like image name, volume name
 // and size
-func Render(imageName, volumeName string, srcVolumeSize int64, targetDiskSize int64) (string, error) {
+func Render(imageName, volumeName string, srcVolumeSize int64, targetDiskSize int64, ImageDist string) (string, error) {
 	//Disk Size should be in bytes
-
-	opt := pkg.ImageCMDOptions
 	osId := "79"
-	if opt.ImageDist == "coreos" {
+	if ImageDist == "coreos" {
 		osId = "80"
 	}
 	o := OVA{
@@ -78,7 +75,7 @@ func RenderMeta(imageName string) (string, error) {
 }
 
 // bundles the dir into a OVA image
-func CreateTarArchive(dir string, target string, targetDiskSize int64) error {
+func CreateTarArchive(dir string, target string, targetDiskSize int64, imageDist string) error {
 	ovf := filepath.Join(dir, VolNameRaw)
 	info, err := os.Stat(ovf)
 	if os.IsNotExist(err) {
@@ -89,7 +86,7 @@ func CreateTarArchive(dir string, target string, targetDiskSize int64) error {
 	if err != nil {
 		return fmt.Errorf("failed to render the meta specfile, got error '%s'", err.Error())
 	}
-	ovfSpec, err := Render(filepath.Base(target), VolNameRaw, volSize, targetDiskSize)
+	ovfSpec, err := Render(filepath.Base(target), VolNameRaw, volSize, targetDiskSize, imageDist)
 	if err != nil {
 		return fmt.Errorf("failed to render the ovf specfile, got error '%s'", err.Error())
 	}

--- a/cmd/image/qcow2ova/ova/template.go
+++ b/cmd/image/qcow2ova/ova/template.go
@@ -36,7 +36,7 @@ var ovfTemplate = `<?xml version="1.0" encoding="UTF-8"?>
         <ovf:Info/>
         <ovf:Product/>
       </ovf:ProductSection>
-      <ovf:OperatingSystemSection ovf:id="79">
+      <ovf:OperatingSystemSection ovf:id="{{.OsId}}">
         <ovf:Info/>
         <ovf:Description>RHEL</ovf:Description>
         <ns0:architecture xmlns:ns0="ibmpvc">ppc64le</ns0:architecture>

--- a/cmd/image/qcow2ova/qcow2ova.go
+++ b/cmd/image/qcow2ova/qcow2ova.go
@@ -227,7 +227,7 @@ Examples:
 
 		klog.Infof("Creating an OVA bundle")
 		ovafile := filepath.Join(tmpDir, opt.ImageName+".ova")
-		if err := ova.CreateTarArchive(ovaImgDir, ovafile, opt.TargetDiskSize); err != nil {
+		if err := ova.CreateTarArchive(ovaImgDir, ovafile, opt.TargetDiskSize, opt.ImageDist); err != nil {
 			return fmt.Errorf("failed to create ova bundle, err: %v", err)
 		}
 		klog.Infof("OVA bundle creation completed: %s", ovafile)


### PR DESCRIPTION
Fix [323](https://github.com/ppc64le-cloud/pvsadm/issues/323)

Updated the os ID in the ovf based on the image distribution  provided.
For coreos os ID is 80 and for other images os ID is added as 79 
