### PR TITLE
Updated unmount function with error handlers

### DIFF
--- a/cmd/image/qcow2ova/prep/loop.go
+++ b/cmd/image/qcow2ova/prep/loop.go
@@ -16,8 +16,10 @@ package prep
 
 import (
 	"fmt"
-	"github.com/ppc64le-cloud/pvsadm/pkg/utils"
 	"strings"
+
+	"github.com/ppc64le-cloud/pvsadm/pkg/utils"
+	"k8s.io/klog/v2"
 )
 
 const losetupCMD = "losetup"
@@ -104,6 +106,20 @@ func mount(opts, src, target string) error {
 func Umount(dir string) error {
 	exitcode, out, err := utils.RunCMD("umount", dir)
 	if exitcode != 0 {
+		if strings.Contains(err, "not mounted") {
+			klog.Infof("Ignoring 'not mounted' error for %s", dir)
+			return nil
+		}
+		if strings.Contains(err, "no mount point specified") {
+			klog.Infof("Ignoring 'no mount point specified' error for %s", dir)
+			return nil
+		}
+		if strings.Contains(err, "target is busy") {
+			exitcode, out, err = utils.RunCMD("umount", "-lf", dir)
+			if exitcode == 0 {
+				return nil
+			}
+		}
 		return fmt.Errorf("failed to unmount, dir: %s, exitcode: %d, stdout: %s, err: %s", dir, exitcode, out, err)
 	}
 	return nil

--- a/cmd/image/qcow2ova/prep/loop.go
+++ b/cmd/image/qcow2ova/prep/loop.go
@@ -17,6 +17,7 @@ package prep
 import (
 	"fmt"
 	"strings"
+
 	"k8s.io/klog/v2"
 
 	"github.com/ppc64le-cloud/pvsadm/pkg/utils"
@@ -121,6 +122,7 @@ func Umount(dir string) error {
 					return nil
 				}
 			}
+			klog.Infof(" As '%s' is busy, unmounting it using lazy unmount", dir)
 			exitcode, out, err = utils.RunCMD("umount", "-lf", dir)
 			if exitcode == 0 {
 				return nil

--- a/cmd/image/qcow2ova/prep/loop.go
+++ b/cmd/image/qcow2ova/prep/loop.go
@@ -115,6 +115,12 @@ func Umount(dir string) error {
 			return nil
 		}
 		if strings.Contains(err, "target is busy") {
+			for retry := 0; retry < 5; retry++ {
+				exitcode, _, err = utils.RunCMD("umount", dir)
+				if exitcode == 0 || strings.Contains(err, "no mount point specified") || strings.Contains(err, "not mounted") {
+					return nil
+				}
+			}
 			exitcode, out, err = utils.RunCMD("umount", "-lf", dir)
 			if exitcode == 0 {
 				return nil

--- a/cmd/image/qcow2ova/prep/loop.go
+++ b/cmd/image/qcow2ova/prep/loop.go
@@ -17,9 +17,9 @@ package prep
 import (
 	"fmt"
 	"strings"
+	"k8s.io/klog/v2"
 
 	"github.com/ppc64le-cloud/pvsadm/pkg/utils"
-	"k8s.io/klog/v2"
 )
 
 const losetupCMD = "losetup"

--- a/cmd/image/qcow2ova/qcow2ova.go
+++ b/cmd/image/qcow2ova/qcow2ova.go
@@ -165,9 +165,10 @@ Examples:
 		go func() {
 			<-c
 			klog.Infof("Received an interrupt, exiting...")
-			_ = os.RemoveAll(tmpDir)
+			prep.ExitChroot()
 			prep.UmountHostPartitions(mnt)
 			_ = prep.Umount(mnt)
+			_ = os.RemoveAll(tmpDir)
 			os.Exit(1)
 		}()
 


### PR DESCRIPTION
Fix: https://github.com/ppc64le-cloud/pvsadm/issues/291

Ignored "not mounted" and "no mount point specified" errors.

For "Target is busy" error, unmounted it safely with lazy unmount.

 