### PR TITLE
Supress NodeJS warnings in GitHub Actions.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,7 +26,7 @@ jobs:
     - run: go version
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -69,7 +69,7 @@ jobs:
     - name: Test
       run: make unit
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: pvsadm-binaries
         path: pvsadm-binaries.tar.gz


### PR DESCRIPTION
Fixes : https://github.com/ppc64le-cloud/pvsadm/issues/376
Changes made:
1. Update actions/checkout@v2 to actions/checkout@v3 and upload-artifact@v2 to upload-artifact@v3, the actions themselves internally use NodeJS 12.
2. Automate Dependabot to manage GitHub-action updates too. 