### PR TITLE
Added groups for commands in help

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -22,9 +22,10 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:   "create",
-	Short: "Create the resources",
-	Long:  `Create the resources`,
+	Use:     "create",
+	Short:   "Create the resources",
+	Long:    `Create the resources`,
+	GroupID: "resource",
 }
 
 func init() {

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -22,9 +22,10 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:   "delete",
-	Short: "Delete the resources",
-	Long:  `Delete the resources`,
+	Use:     "delete",
+	Short:   "Delete the resources",
+	Long:    `Delete the resources`,
+	GroupID: "resource",
 }
 
 func init() {

--- a/cmd/dhcp-sync/dhcp-sync.go
+++ b/cmd/dhcp-sync/dhcp-sync.go
@@ -149,9 +149,10 @@ func syncDHCPD() {
 }
 
 var Cmd = &cobra.Command{
-	Use:   "dhcp-sync",
-	Short: "dhcp-sync command",
-	Long:  `dhcp-sync tool is a tool populating the dhcpd.conf file from the PowerVS network and restart the dhcpd service.`,
+	Use:     "dhcp-sync",
+	Short:   "dhcp-sync command",
+	Long:    `dhcp-sync tool is a tool populating the dhcpd.conf file from the PowerVS network and restart the dhcpd service.`,
+	GroupID: "dhcp",
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if pkg.Options.InstanceID == "" {
 			return fmt.Errorf("--instance-id is required")

--- a/cmd/dhcpserver/cmd.go
+++ b/cmd/dhcpserver/cmd.go
@@ -23,8 +23,9 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:   "dhcpserver",
-	Short: "dhcpserver command",
+	Use:     "dhcpserver",
+	Short:   "dhcpserver command",
+	GroupID: "dhcp",
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if pkg.Options.APIKey == "" {
 			return fmt.Errorf("api-key can't be empty, pass the token via --api-key or set IBMCLOUD_API_KEY environment variable")

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -23,9 +23,10 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:   "get",
-	Short: "Get the resources",
-	Long:  `Get the resources`,
+	Use:     "get",
+	Short:   "Get the resources",
+	Long:    `Get the resources`,
+	GroupID: "resource",
 }
 
 func init() {

--- a/cmd/image/image.go
+++ b/cmd/image/image.go
@@ -24,9 +24,10 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:   "image",
-	Short: "PowerVS Image management",
-	Long:  `PowerVS Image management`,
+	Use:     "image",
+	Short:   "PowerVS Image management",
+	Long:    `PowerVS Image management`,
+	GroupID: "image",
 }
 
 func init() {

--- a/cmd/purge/images/images.go
+++ b/cmd/purge/images/images.go
@@ -16,6 +16,7 @@ package images
 
 import (
 	"fmt"
+
 	"github.com/ppc64le-cloud/pvsadm/pkg"
 	"github.com/ppc64le-cloud/pvsadm/pkg/audit"
 	"github.com/ppc64le-cloud/pvsadm/pkg/client"

--- a/cmd/purge/purge.go
+++ b/cmd/purge/purge.go
@@ -69,6 +69,7 @@ Examples:
   # Delete all the ssh keys starts with rdr-
   pvsadm purge keys --instance-name upstream-core --regexp "^rdr-.*"
 `,
+	GroupID: "resource",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		// Code block to execute the strict check mentioned in the rootcmd for the environment.
 		// This block is needed as a workaround mentioned in https://github.com/spf13/cobra/issues/252

--- a/cmd/purge/volumes/volumes.go
+++ b/cmd/purge/volumes/volumes.go
@@ -16,13 +16,14 @@ package volumes
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/ppc64le-cloud/pvsadm/pkg"
 	"github.com/ppc64le-cloud/pvsadm/pkg/audit"
 	"github.com/ppc64le-cloud/pvsadm/pkg/client"
 	"github.com/ppc64le-cloud/pvsadm/pkg/utils"
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
-	"time"
 )
 
 var before time.Duration

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -63,6 +63,12 @@ func init() {
 	klog.InitFlags(nil)
 	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 
+	rootCmd.AddGroup(&cobra.Group{ID: "resource", Title: "Resource Management Commands:"})
+	rootCmd.AddGroup(&cobra.Group{ID: "dhcp", Title: "DHCP Commands:"})
+	rootCmd.AddGroup(&cobra.Group{ID: "image", Title: "Image Commands:"})
+	rootCmd.AddGroup(&cobra.Group{ID: "admin", Title: "Administration Commands:"})
+	rootCmd.SetHelpCommandGroupID("admin")
+	rootCmd.SetCompletionCommandGroupID("admin")
 	rootCmd.AddCommand(purge.Cmd)
 	rootCmd.AddCommand(get.Cmd)
 	rootCmd.AddCommand(version.Cmd)

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -16,15 +16,17 @@ package version
 
 import (
 	"fmt"
-	"github.com/ppc64le-cloud/pvsadm/pkg/version"
 	"runtime"
+
+	"github.com/ppc64le-cloud/pvsadm/pkg/version"
 
 	"github.com/spf13/cobra"
 )
 
 var Cmd = &cobra.Command{
-	Use:   "version",
-	Short: "Print the version number",
+	Use:     "version",
+	Short:   "Print the version number",
+	GroupID: "admin",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Printf("Version: %s, GoVersion: %s\n", version.Get(), runtime.Version())
 	},


### PR DESCRIPTION
Fix for https://github.com/ppc64le-cloud/pvsadm/issues/347

Added groups for commands in help

```
./pvsadm help               
I0314 21:28:53.205226   35870 root.go:50] Using an API key from IBMCLOUD_API_KEY environment variable
Power Systems Virtual Server projects deliver flexible compute capacity for Power Systems workloads.
Integrated with the IBM Cloud platform for on-demand provisioning.

This is a tool built for the Power Systems Virtual Server helps managing and maintaining the resources easily

Usage:
  pvsadm [command]

Resource Management Commands:
  create      Create the resources
  delete      Delete the resources
  get         Get the resources
  purge       Purge the powervs resources

DHCP Commands:
  dhcp-sync   dhcp-sync command
  dhcpserver  dhcpserver command

Image Commands:
  image       PowerVS Image management

Administration Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  version     Print the version number
```

