### PR TITLE
Update go version to 1.20

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,7 +9,7 @@ on:
     branches: [ main ]
 
 env:
-  GO_VERSION: "1.19"
+  GO_VERSION: "1.20"
 
 jobs:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 env:
-  GO_VERSION: "1.19"
+  GO_VERSION: "1.20"
 
 jobs:
   build:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ppc64le-cloud/pvsadm
 
-go 1.19
+go 1.20
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.6


### PR DESCRIPTION
Changes:
- Update go version to 1.20 in go.mod file.
- Use go 1.20 for build and release workflows.