### PR TITLE
Added fix for passwd: Authentication token manipulation error

### DIFF
--- a/cmd/image/qcow2ova/prep/templates.go
+++ b/cmd/image/qcow2ova/prep/templates.go
@@ -68,7 +68,7 @@ done
 grub2-mkconfig -o /boot/grub2/grub.cfg
 rm -rf /etc/sysconfig/network-scripts/ifcfg-eth0
 {{if .RootPasswd }}
-echo {{ .RootPasswd }} | passwd root --stdin
+echo root:{{ .RootPasswd }} | chpasswd
 {{end}}
 {{if eq .Dist "rhel"}}
 subscription-manager unregister


### PR DESCRIPTION
Fix https://github.com/ppc64le-cloud/pvsadm/issues/455

Modified `passwd` to `chpasswd` command  for changing the root password.

```
$pvsadm image qcow2ova  --image-name rhel-90-test --image-url /root/rhel-baseos-9.1-ppc64le-kvm.qcow2  --image-dist rhel  --rhn-user ***l --os-password Root123#

Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                        1/1 
  Installing       : libaio-0.3.111-13.el9.ppc64le                          1/3 
  Installing       : device-mapper-multipath-libs-0.8.7-20.el9.ppc64le      2/3 
  Installing       : device-mapper-multipath-0.8.7-20.el9.ppc64le           3/3 
  Running scriptlet: device-mapper-multipath-0.8.7-20.el9.ppc64le           3/3 
Created symlink /etc/systemd/system/sysinit.target.wants/multipathd.service → /usr/lib/systemd/system/multipathd.service.
Created symlink /etc/systemd/system/sockets.target.wants/multipathd.socket → /usr/lib/systemd/system/multipathd.socket.

Running in chroot, ignoring request.

Running in chroot, ignoring command 'daemon-reload'
Running in chroot, ignoring command 'reload-or-restart'

  Verifying        : libaio-0.3.111-13.el9.ppc64le                          1/3 
  Verifying        : device-mapper-multipath-libs-0.8.7-20.el9.ppc64le      2/3 
  Verifying        : device-mapper-multipath-0.8.7-20.el9.ppc64le           3/3 
Installed products updated.

Installed:
  device-mapper-multipath-0.8.7-20.el9.ppc64le                                  
  device-mapper-multipath-libs-0.8.7-20.el9.ppc64le                             
  libaio-0.3.111-13.el9.ppc64le                                                 

Complete!
Generating initramfs for kernel version: 5.14.0-162.6.1.el9_1.ppc64le
Generating initramfs for kernel version: 5.14.0-284.30.1.el9_2.ppc64le
Generating grub configuration file ...
Adding boot menu entry for UEFI Firmware Settings ...
done
Unregistering from: subscription.rhsm.redhat.com:443/subscription
System has been unregistered.
All local data removed
mv: cannot stat '/etc/resolv.conf.orig': No such file or directory
I1012 18:01:17.136787    2523 qcow2ova.go:227] Preparation completed
I1012 18:01:17.136822    2523 qcow2ova.go:229] Creating an OVA bundle
I1012 18:01:26.380681    2523 qcow2ova.go:234] OVA bundle creation completed: /tmp/qcow2ova1208226242/rhel-90-test.ova
I1012 18:01:26.380717    2523 qcow2ova.go:236] Compressing an OVA file
I1012 18:01:36.956318    2523 qcow2ova.go:242] OVA file Compression completed


Successfully converted Qcow2 image to OVA format, find at /root/new/pvsadm/rhel-90-test.ova.gz
OS root password: Root123#

```