### PR TITLE
Added fix for passwd: Authentication token manipulation error

### DIFF
--- a/cmd/image/qcow2ova/prep/templates.go
+++ b/cmd/image/qcow2ova/prep/templates.go
@@ -31,6 +31,9 @@ echo "nameserver 9.9.9.9" | tee /etc/resolv.conf
 {{if eq .Dist "rhel"}}
 subscription-manager register --force --auto-attach --username={{ .RHNUser }} --password={{ .RHNPassword }}
 {{end}}
+{{if .RootPasswd }}
+echo {{ .RootPasswd }} | passwd root --stdin
+{{end}}
 yum update -y && yum install -y yum-utils
 yum install -y cloud-init
 yum reinstall grub2-common -y
@@ -67,9 +70,6 @@ do
 done
 grub2-mkconfig -o /boot/grub2/grub.cfg
 rm -rf /etc/sysconfig/network-scripts/ifcfg-eth0
-{{if .RootPasswd }}
-echo {{ .RootPasswd }} | passwd root --stdin
-{{end}}
 {{if eq .Dist "rhel"}}
 subscription-manager unregister
 subscription-manager clean


### PR DESCRIPTION
Fix https://github.com/ppc64le-cloud/pvsadm/issues/455

Image: rhel-9.2-ppc64le-kvm.qcow2 
```
./pvsadm image qcow2ova  --image-name rhel-92-test --image-url /root/rhel-9.2-ppc64le-kvm.qcow2  --image-dist rhel --os-password TyBU84GrbPD75FsT --rhn-user ****
W1017 16:23:26.390945  533571 qcow2ova.go:95] rhn-user and rhn-password options are mandatory when image-dist is rhel, please enter the details
✗ Enter the RHN Password: █
Enter the RHN Password: ••••••••••••••••••
I1017 16:23:40.889617  533571 validate.go:40] Checking: platform
I1017 16:23:40.889635  533571 validate.go:40] Checking: user
I1017 16:23:40.889645  533571 validate.go:40] Checking: image-name
I1017 16:23:40.889680  533571 validate.go:40] Checking: tools
I1017 16:23:40.889722  533571 tools.go:43] qemu-img found at /usr/bin/qemu-img
I1017 16:23:40.889746  533571 tools.go:43] growpart found at /usr/bin/growpart
I1017 16:23:40.889754  533571 validate.go:40] Checking: diskspace
I1017 16:23:40.889826  533571 diskspace.go:50] free: 67G, need: 61G
I1017 16:23:40.890053  533571 get-image.go:43] Copying /root/rhel-9.2-ppc64le-kvm.qcow2 into /tmp/qcow2ova2641854591/rhel-9.2-ppc64le-kvm.qcow2
I1017 16:23:41.372402  533571 get-image.go:47] Copy Completed!
I1017 16:23:41.372478  533571 qcow2ova.go:180] downloaded/copied the file at: /tmp/qcow2ova2641854591/rhel-9.2-ppc64le-kvm.qcow2
I1017 16:23:41.372760  533571 qcow2ova.go:208] Converting Qcow2(/tmp/qcow2ova2641854591/rhel-9.2-ppc64le-kvm.qcow2) image to raw(/tmp/qcow2ova2641854591/ova-img-dir/disk.raw) format
I1017 16:23:43.305147  533571 qcow2ova.go:213] Conversion completed
I1017 16:23:43.305185  533571 qcow2ova.go:215] Resizing the image /tmp/qcow2ova2641854591/ova-img-dir/disk.raw to 11G
Image resized.
I1017 16:23:43.663943  533571 qcow2ova.go:220] Resize completed
I1017 16:23:43.663958  533571 qcow2ova.go:222] Preparing the image
/dev/loop10
3
CHANGED: partition=3 start=1034240 old: size=19937280 end=20971519 new: size=22034399 end=23068638
xfs
meta-data=/dev/loop10p3          isize=512    agcount=4, agsize=623040 blks
         =                       sectsz=512   attr=2, projid32bit=1
         =                       crc=1        finobt=1, sparse=1, rmapbt=0
         =                       reflink=1    bigtime=0 inobtcount=0
data     =                       bsize=4096   blocks=2492160, imaxpct=25
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0, ftype=1
log      =internal log           bsize=4096   blocks=2560, version=2
         =                       sectsz=512   sunit=0 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0
data blocks changed from 2492160 to 2754299
mv: cannot stat '/etc/resolv.conf': No such file or directory
nameserver 9.9.9.9
Registering to: subscription.rhsm.redhat.com:443/subscription
The system has been registered with ID: d6d26657-6f11-4cf3-8de2-827d17399d9a
The registered system name is: keerthana-vm
Ignoring the request to auto-attach. Attaching subscriptions is disabled for organization "11009103" because Simple Content Access (SCA) is enabled.

WARNING

The yum/dnf plugins: /etc/dnf/plugins/subscription-manager.conf, /etc/dnf/plugins/product-id.conf were automatically enabled for the benefit of Red Hat Subscription Management. If not desired, use "subscription-manager config --rhsm.auto_enable_yum_plugins=0" to block this behavior.

Changing password for user root.
passwd: all authentication tokens updated successfully.
.
.
.

Adding boot menu entry for UEFI Firmware Settings ...
done
Unregistering from: subscription.rhsm.redhat.com:443/subscription
System has been unregistered.
All local data removed
mv: cannot stat '/etc/resolv.conf.orig': No such file or directory
I1017 16:29:49.016312  533571 qcow2ova.go:227] Preparation completed
I1017 16:29:49.016341  533571 qcow2ova.go:229] Creating an OVA bundle
I1017 16:29:58.265101  533571 qcow2ova.go:234] OVA bundle creation completed: /tmp/qcow2ova2641854591/rhel-92-test.ova
I1017 16:29:58.265155  533571 qcow2ova.go:236] Compressing an OVA file
I1017 16:30:09.175657  533571 qcow2ova.go:242] OVA file Compression completed


Successfully converted Qcow2 image to OVA format, find at /root/new/pvsadm/rhel-92-test.ova.gz
```


Image:  rhel-baseos-9.1-ppc64le-kvm.qcow2

```
./pvsadm image qcow2ova  --image-name rhel-91-test --image-url /root/rhel-baseos-9.1-ppc64le-kvm.qcow2  --image-dist rhel --os-password TyBU84GrbPD75FsT --rhn-user ****
W1017 16:38:56.168437  579022 qcow2ova.go:95] rhn-user and rhn-password options are mandatory when image-dist is rhel, please enter the details
✗ Enter the RHN Password: █
Enter the RHN Password: ••••••••••••••••••
I1017 16:39:03.694223  579022 validate.go:40] Checking: platform
I1017 16:39:03.694234  579022 validate.go:40] Checking: user
I1017 16:39:03.694242  579022 validate.go:40] Checking: image-name
I1017 16:39:03.694275  579022 validate.go:40] Checking: tools
I1017 16:39:03.694317  579022 tools.go:43] qemu-img found at /usr/bin/qemu-img
I1017 16:39:03.694341  579022 tools.go:43] growpart found at /usr/bin/growpart
I1017 16:39:03.694348  579022 validate.go:40] Checking: diskspace
I1017 16:39:03.694361  579022 diskspace.go:50] free: 62G, need: 61G
I1017 16:39:03.694596  579022 get-image.go:43] Copying /root/rhel-baseos-9.1-ppc64le-kvm.qcow2 into /tmp/qcow2ova3064415453/rhel-baseos-9.1-ppc64le-kvm.qcow2
I1017 16:39:04.164259  579022 get-image.go:47] Copy Completed!
I1017 16:39:04.164316  579022 qcow2ova.go:180] downloaded/copied the file at: /tmp/qcow2ova3064415453/rhel-baseos-9.1-ppc64le-kvm.qcow2
I1017 16:39:04.164473  579022 qcow2ova.go:208] Converting Qcow2(/tmp/qcow2ova3064415453/rhel-baseos-9.1-ppc64le-kvm.qcow2) image to raw(/tmp/qcow2ova3064415453/ova-img-dir/disk.raw) format
I1017 16:39:06.035837  579022 qcow2ova.go:213] Conversion completed
I1017 16:39:06.035887  579022 qcow2ova.go:215] Resizing the image /tmp/qcow2ova3064415453/ova-img-dir/disk.raw to 11G
Image resized.
I1017 16:39:06.569000  579022 qcow2ova.go:220] Resize completed
I1017 16:39:06.569016  579022 qcow2ova.go:222] Preparing the image
/dev/loop11
3
CHANGED: partition=3 start=1034240 old: size=19937280 end=20971519 new: size=22034399 end=23068638
xfs
meta-data=/dev/loop11p3          isize=512    agcount=4, agsize=623040 blks
         =                       sectsz=512   attr=2, projid32bit=1
         =                       crc=1        finobt=1, sparse=1, rmapbt=0
         =                       reflink=1    bigtime=0 inobtcount=0
data     =                       bsize=4096   blocks=2492160, imaxpct=25
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0, ftype=1
log      =internal log           bsize=4096   blocks=2560, version=2
         =                       sectsz=512   sunit=0 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0
data blocks changed from 2492160 to 2754299
mv: cannot stat '/etc/resolv.conf': No such file or directory
nameserver 9.9.9.9
Registering to: subscription.rhsm.redhat.com:443/subscription
The system has been registered with ID: 20421889-9881-46d9-b80f-29d38d5a3c3c
The registered system name is: keerthana-vm
Ignoring request to auto-attach. It is disabled for org "11009103" because of the content access mode setting.

WARNING

The yum/dnf plugins: /etc/dnf/plugins/subscription-manager.conf, /etc/dnf/plugins/product-id.conf were automatically enabled for the benefit of Red Hat Subscription Management. If not desired, use "subscription-manager config --rhsm.auto_enable_yum_plugins=0" to block this behavior.

Changing password for user root.
passwd: all authentication tokens updated successfully.
.
.
.
I1017 16:45:48.145691  579022 qcow2ova.go:227] Preparation completed
I1017 16:45:48.145726  579022 qcow2ova.go:229] Creating an OVA bundle
I1017 16:45:57.177322  579022 qcow2ova.go:234] OVA bundle creation completed: /tmp/qcow2ova3064415453/rhel-91-test.ova
I1017 16:45:57.177393  579022 qcow2ova.go:236] Compressing an OVA file
I1017 16:46:08.006235  579022 qcow2ova.go:242] OVA file Compression completed


Successfully converted Qcow2 image to OVA format, find at /root/new/pvsadm/rhel-91-test.ova.gz
OS root password: TyBU84GrbPD75FsT
```

Image: rhel-baseos-9.0-ppc64le-kvm.qcow2

```
./pvsadm image qcow2ova  --image-name rhel-90-test --image-url /root/rhel-baseos-9.0-ppc64le-kvm.qcow2  --image-dist rhel --os-password TyBU84GrbPD75FsT --rhn-user rh-ee-sgokul
W1017 16:56:49.957533    2411 qcow2ova.go:95] rhn-user and rhn-password options are mandatory when image-dist is rhel, please enter the details
✗ Enter the RHN Password: █
Enter the RHN Password: ••••••••••••••••••
I1017 16:56:56.235088    2411 validate.go:40] Checking: platform
I1017 16:56:56.235410    2411 validate.go:40] Checking: user
I1017 16:56:56.235425    2411 validate.go:40] Checking: image-name
I1017 16:56:56.235461    2411 validate.go:40] Checking: tools
I1017 16:56:56.236676    2411 tools.go:43] qemu-img found at /usr/bin/qemu-img
I1017 16:56:56.236735    2411 tools.go:43] growpart found at /usr/bin/growpart
I1017 16:56:56.236745    2411 validate.go:40] Checking: diskspace
I1017 16:56:56.236763    2411 diskspace.go:50] free: 84G, need: 61G
I1017 16:56:56.238240    2411 get-image.go:43] Copying /root/rhel-baseos-9.0-ppc64le-kvm.qcow2 into /tmp/qcow2ova1323740334/rhel-baseos-9.0-ppc64le-kvm.qcow2
I1017 16:56:56.691243    2411 get-image.go:47] Copy Completed!
I1017 16:56:56.691311    2411 qcow2ova.go:180] downloaded/copied the file at: /tmp/qcow2ova1323740334/rhel-baseos-9.0-ppc64le-kvm.qcow2
I1017 16:56:56.691903    2411 qcow2ova.go:208] Converting Qcow2(/tmp/qcow2ova1323740334/rhel-baseos-9.0-ppc64le-kvm.qcow2) image to raw(/tmp/qcow2ova1323740334/ova-img-dir/disk.raw) format
I1017 16:56:58.505644    2411 qcow2ova.go:213] Conversion completed
I1017 16:56:58.505902    2411 qcow2ova.go:215] Resizing the image /tmp/qcow2ova1323740334/ova-img-dir/disk.raw to 11G
Image resized.
I1017 16:56:59.305556    2411 qcow2ova.go:220] Resize completed
I1017 16:56:59.305575    2411 qcow2ova.go:222] Preparing the image
/dev/loop0
3
CHANGED: partition=3 start=1034240 old: size=19937280 end=20971519 new: size=22034399 end=23068638
xfs
meta-data=/dev/loop0p3           isize=512    agcount=4, agsize=623040 blks
         =                       sectsz=512   attr=2, projid32bit=1
         =                       crc=1        finobt=1, sparse=1, rmapbt=0
         =                       reflink=1    bigtime=0 inobtcount=0
data     =                       bsize=4096   blocks=2492160, imaxpct=25
         =                       sunit=0      swidth=0 blks
naming   =version 2              bsize=4096   ascii-ci=0, ftype=1
log      =internal log           bsize=4096   blocks=2560, version=2
         =                       sectsz=512   sunit=0 blks, lazy-count=1
realtime =none                   extsz=4096   blocks=0, rtextents=0
data blocks changed from 2492160 to 2754299
mv: cannot stat '/etc/resolv.conf': No such file or directory
nameserver 9.9.9.9
Registering to: subscription.rhsm.redhat.com:443/subscription
The system has been registered with ID: 8709c84a-2522-4dfa-9e15-743a61e7d23c
The registered system name is: keerthana-vm
Ignoring request to auto-attach. It is disabled for org "11009103" because of the content access mode setting.

WARNING

The yum/dnf plugins: /etc/dnf/plugins/subscription-manager.conf, /etc/dnf/plugins/product-id.conf were automatically enabled for the benefit of Red Hat Subscription Management. If not desired, use "subscription-manager config --rhsm.auto_enable_yum_plugins=0" to block this behavior.

Changing password for user root.
passwd: all authentication tokens updated successfully.
.
.
.
I1017 17:01:51.076041    2411 qcow2ova.go:227] Preparation completed
I1017 17:01:51.076085    2411 qcow2ova.go:229] Creating an OVA bundle
I1017 17:01:59.668323    2411 qcow2ova.go:234] OVA bundle creation completed: /tmp/qcow2ova1323740334/rhel-90-test.ova
I1017 17:01:59.668378    2411 qcow2ova.go:236] Compressing an OVA file
I1017 17:02:10.786201    2411 qcow2ova.go:242] OVA file Compression completed


Successfully converted Qcow2 image to OVA format, find at /root/new/pvsadm/rhel-90-test.ova.gz
OS root password: TyBU84GrbPD75FsT
```



