### PR TITLE
Added image links to the qcow2ova help

### DIFF
--- a/cmd/image/qcow2ova/qcow2ova.go
+++ b/cmd/image/qcow2ova/qcow2ova.go
@@ -61,6 +61,15 @@ Examples:
   # Step 2 - Make the necessary changes to the above generated template file(bash shell script) - image-prep.template
   # Step 3 - Run the qcow2ova with the modified image preparation template
   pvsadm image qcow2ova --image-name centos-82 --image-dist centos --image-url /root/CentOS-8-GenericCloud-8.2.2004-20200611.2.ppc64le.qcow2 --prep-template image-prep.template
+
+Qcow2 images location:
+
+  # CentOS 8:     https://cloud.centos.org/centos/8-stream/ppc64le/images/
+  # CentOS 9:     https://cloud.centos.org/centos/9-stream/ppc64le/images/
+  # Old Centos:   https://cloud.centos.org/centos/8/ppc64le/images/
+  # RHEL image:   https://access.redhat.com/downloads/content/279/ver=/rhel---8/8.3/ppc64le/product-software 
+  # RHCOS images: https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/
+
 `,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		opt := pkg.ImageCMDOptions


### PR DESCRIPTION
Fix https://github.com/ppc64le-cloud/pvsadm/issues/47
```
pvsadm image qcow2ova --help
Convert the qcow2 image to ova format

Examples:

  # Downloads the coreos image from remote site and converts into ova type with name rhcos-461.ova.gz
  pvsadm image qcow2ova --image-name rhcos-461 --image-dist coreos --image-url https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/4.6/4.6.1/rhcos-4.6.1-ppc64le-openstack.ppc64le.qcow2.gz

  # Converts the CentOS image from the local filesystem with size 50GB
  pvsadm image qcow2ova --image-name centos-82 --image-dist centos --image-size 50 --image-url /root/CentOS-8-GenericCloud-8.2.2004-20200611.2.ppc64le.qcow2

  # Converts the RHEL image from local filesystem
  pvsadm image qcow2ova --image-name rhel-82-29oct --image-dist rhel --rhn-user joesmith@example.com --rhn-password someValidPassword --image-url ./rhel-8.2-update-2-ppc64le-kvm.qcow2

  # Converts the CentOS image from the local filesystem with OS password set
  pvsadm image qcow2ova --image-name centos-82 --image-dist centos --os-password s0meC0mplexPassword --image-url /root/CentOS-8-GenericCloud-8.2.2004-20200611.2.ppc64le.qcow2

  # Converts the CentOS image from the local filesystem without OS password
  pvsadm image qcow2ova --image-name centos-82 --image-dist centos  --image-url /root/CentOS-8-GenericCloud-8.2.2004-20200611.2.ppc64le.qcow2 --skip-os-password

  # Customize the image preparation script for RHEL/CentOS distro, e.g: add additional yum repository or packages, change name servers etc. 
  # Step 1 - Dump the default image preparation template
  pvsadm image qcow2ova --prep-template-default > image-prep.template
  # Step 2 - Make the necessary changes to the above generated template file(bash shell script) - image-prep.template
  # Step 3 - Run the qcow2ova with the modified image preparation template
  pvsadm image qcow2ova --image-name centos-82 --image-dist centos --image-url /root/CentOS-8-GenericCloud-8.2.2004-20200611.2.ppc64le.qcow2 --prep-template image-prep.template

Qcow2 images location:

  # CentOS 8:     https://cloud.centos.org/centos/8-stream/ppc64le/images/
  # CentOS 9:     https://cloud.centos.org/centos/9-stream/ppc64le/images/
  # Old Centos:   https://cloud.centos.org/centos/8/ppc64le/images/
  # RHEL image:   https://access.redhat.com/downloads/content/279/ver=/rhel---8/8.3/ppc64le/product-software 
  # RHCOS images: https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/

Usage:
  pvsadm image qcow2ova [flags]
```
