### PR TITLE
Cloud-config template made configurable.

### DIFF
--- a/cmd/image/qcow2ova/prep/prepare.go
+++ b/cmd/image/qcow2ova/prep/prepare.go
@@ -16,11 +16,12 @@ package prep
 
 import (
 	"fmt"
-	"github.com/ppc64le-cloud/pvsadm/pkg/utils"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/ppc64le-cloud/pvsadm/pkg/utils"
 
 	"k8s.io/klog/v2"
 )
@@ -101,7 +102,7 @@ func prepare(mnt, volume, dist, rhnuser, rhnpasswd, rootpasswd string) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(filepath.Join(mnt, "/etc/cloud/cloud.cfg"), []byte(cloudConfig), 0644)
+	err = ioutil.WriteFile(filepath.Join(mnt, "/etc/cloud/cloud.cfg"), []byte(CloudConfig), 0644)
 	if err != nil {
 		return err
 	}

--- a/cmd/image/qcow2ova/prep/templates.go
+++ b/cmd/image/qcow2ova/prep/templates.go
@@ -82,7 +82,7 @@ mv /etc/resolv.conf.orig /etc/resolv.conf || true
 touch /.autorelabel
 `
 
-var cloudConfig = `# latest file from cloud-init-22.1-1.el8.noarch
+var CloudConfig = `# latest file from cloud-init-22.1-1.el8.noarch
 users:
  - default
 

--- a/pkg/options.go
+++ b/pkg/options.go
@@ -52,6 +52,8 @@ type imageCMDOptions struct {
 	TempDir             string
 	PrepTemplate        string
 	PrepTemplateDefault bool
+	CloudConfig         string
+	CloudConfigDefault  bool
 	OSPasswordSkip      bool
 	//upload options
 	InstanceName string


### PR DESCRIPTION

Fix https://github.com/ppc64le-cloud/pvsadm/issues/86

Added cloud-config template option for user to override.
```
$pvsadm image qcow2ova  --image-name rhel-90-test --image-url /root/rhel-baseos-9.0-ppc64le-kvm.qcow2  --image-dist rhel --os-password TyBU84GrbPD75FsT --rhn-user rh-ee-sgokul --cloud-config user_cloud.config -v 3

I1107 09:06:42.446684 1016706 qcow2ova.go:96] Overriding with the user defined cloud config.
W1107 09:06:42.446804 1016706 qcow2ova.go:112] rhn-user and rhn-password options are mandatory when image-dist is rhel, please enter the details
```
