### PR TITLE
Give the raw disk image a more meaningful name

### DIFF
--- a/cmd/image/qcow2ova/qcow2ova.go
+++ b/cmd/image/qcow2ova/qcow2ova.go
@@ -233,7 +233,7 @@ Qcow2 images location:
 			return err
 		}
 
-		rawImg := filepath.Join(ovaImgDir, ova.VolNameRaw)
+		rawImg := filepath.Join(ovaImgDir, fmt.Sprintf("%s-%s", opt.ImageName, ova.VolNameRaw))
 
 		klog.Infof("Converting Qcow2(%s) image to raw(%s) format", qcow2Img, rawImg)
 		err = qemuImgConvertQcow2Raw(qcow2Img, rawImg)


### PR DESCRIPTION
This makes it easier to see what types of OSes are running and provide a little more detail from the "Volumes" view in PowerVS.

IBM i, for example, names their .raw files "IBMi-\<version\>-img.raw".