### PR TITLE
Use alternate package for ioutil

### DIFF
--- a/cmd/dhcp-sync/dhcp-sync.go
+++ b/cmd/dhcp-sync/dhcp-sync.go
@@ -16,8 +16,8 @@ package dhcp
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -93,6 +93,9 @@ func syncDHCPD() {
 	}
 
 	n, err := pvmclient.NetworkClient.Get(networkID)
+	if err != nil {
+		klog.Fatalf("failed to fetch network by ID: %v", err)
+	}
 
 	ipv4Addr, ipv4Net, err := net.ParseCIDR(*n.Cidr)
 	if err != nil {
@@ -144,7 +147,9 @@ func syncDHCPD() {
 
 	content := fmt.Sprintf(dhcpdTemplate, subnetStmt.IndentedString(""))
 	mutex.Lock()
-	ioutil.WriteFile(file, []byte(content), 0644)
+	if err = os.WriteFile(file, []byte(content), 0644); err != nil {
+		klog.Fatalf("cannot write to dhcp.conf file: %v", err)
+	}
 	mutex.Unlock()
 }
 

--- a/cmd/image/info/info.go
+++ b/cmd/image/info/info.go
@@ -17,7 +17,7 @@ package info
 import (
 	"encoding/xml"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -97,7 +97,7 @@ pvsadm image info rhcos-46-12152021.ova.gz
 		}
 		defer xmlFile.Close()
 		var version Ovf
-		byteValue, err := ioutil.ReadAll(xmlFile)
+		byteValue, err := io.ReadAll(xmlFile)
 		if err != nil {
 			return err
 		}

--- a/cmd/image/qcow2ova/get-image_test.go
+++ b/cmd/image/qcow2ova/get-image_test.go
@@ -16,7 +16,6 @@ package qcow2ova
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -43,27 +42,27 @@ func Test_getImage(t *testing.T) {
 		fmt.Fprintf(w, "Hello World!")
 	})
 	mux.HandleFunc("/fail", func(w http.ResponseWriter, req *http.Request) {
-		http.Error(w, fmt.Sprintf("failed to handle the build"), http.StatusInternalServerError)
+		http.Error(w, "failed to handle the build", http.StatusInternalServerError)
 	})
 
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
 
 	content := []byte("temporary file's content")
-	dir, err := ioutil.TempDir("", "example")
+	dir, err := os.MkdirTemp("", "example")
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer os.RemoveAll(dir)
 
-	destDir, err := ioutil.TempDir("", "example")
+	destDir, err := os.MkdirTemp("", "example")
 	if err != nil {
 		log.Fatal(err)
 	}
 	//defer os.RemoveAll(destDir)
 
 	tmpfn := filepath.Join(dir, "tmpfile")
-	if err := ioutil.WriteFile(tmpfn, content, 0666); err != nil {
+	if err := os.WriteFile(tmpfn, content, 0666); err != nil {
 		log.Fatal(err)
 	}
 

--- a/cmd/image/qcow2ova/prep/prepare.go
+++ b/cmd/image/qcow2ova/prep/prepare.go
@@ -16,7 +16,6 @@ package prep
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -97,17 +96,17 @@ func prepare(mnt, volume, dist, rhnuser, rhnpasswd, rootpasswd string) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(filepath.Join(mnt, "setup.sh"), []byte(setupStr), 0744)
+	err = os.WriteFile(filepath.Join(mnt, "setup.sh"), []byte(setupStr), 0744)
 	if err != nil {
 		return err
 	}
 
-	err = ioutil.WriteFile(filepath.Join(mnt, "/etc/cloud/cloud.cfg"), []byte(CloudConfig), 0644)
+	err = os.WriteFile(filepath.Join(mnt, "/etc/cloud/cloud.cfg"), []byte(CloudConfig), 0644)
 	if err != nil {
 		return err
 	}
 
-	err = ioutil.WriteFile(filepath.Join(mnt, "/etc/cloud/ds-identify.cfg"), []byte(dsIdentify), 0644)
+	err = os.WriteFile(filepath.Join(mnt, "/etc/cloud/ds-identify.cfg"), []byte(dsIdentify), 0644)
 	if err != nil {
 		return err
 	}

--- a/cmd/image/qcow2ova/qcow2ova.go
+++ b/cmd/image/qcow2ova/qcow2ova.go
@@ -16,7 +16,6 @@ package qcow2ova
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -98,7 +97,7 @@ Qcow2 images location:
 				return fmt.Errorf("--prep-template option is not supported for coreos distro")
 			} else {
 				klog.Info("Overriding with the user defined image preparation template.")
-				content, err := ioutil.ReadFile(opt.PrepTemplate)
+				content, err := os.ReadFile(opt.PrepTemplate)
 				if err != nil {
 					return err
 				}
@@ -107,7 +106,7 @@ Qcow2 images location:
 		}
 		if opt.CloudConfig != "" {
 			klog.V(2).Info("Overriding with the user defined cloud config.")
-			content, err := ioutil.ReadFile(opt.CloudConfig)
+			content, err := os.ReadFile(opt.CloudConfig)
 			if err != nil {
 				return err
 			}
@@ -172,7 +171,7 @@ Qcow2 images location:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		opt := pkg.ImageCMDOptions
 
-		tmpDir, err := ioutil.TempDir(opt.TempDir, "qcow2ova")
+		tmpDir, err := os.MkdirTemp(opt.TempDir, "qcow2ova")
 		if err != nil {
 			return fmt.Errorf("failed to create a temprory directory: %v", err)
 		}

--- a/cmd/image/sync/sync.go
+++ b/cmd/image/sync/sync.go
@@ -16,7 +16,7 @@ package sync
 
 import (
 	"errors"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -160,7 +160,7 @@ func getResults(results <-chan bool, totalChannels int) bool {
 func getSpec(specfileName string) ([]pkg.Spec, error) {
 	var spec []pkg.Spec
 	// Unmashalling yaml file
-	yamlFile, err := ioutil.ReadFile(specfileName)
+	yamlFile, err := os.ReadFile(specfileName)
 	if err != nil {
 		klog.Errorf("ERROR: Read yaml failed : %v", err)
 		return nil, err

--- a/cmd/image/sync/sync_test.go
+++ b/cmd/image/sync/sync_test.go
@@ -16,7 +16,6 @@ package sync
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"testing"
@@ -74,7 +73,7 @@ func TestGetSpec(t *testing.T) {
 		spec := mockCreateSpec()
 
 		// test case verification section
-		file, err := ioutil.TempFile("", "spec.*.yaml")
+		file, err := os.CreateTemp("", "spec.*.yaml")
 		require.NoError(t, err, "Error creating specfile")
 		defer file.Close()
 

--- a/test/e2e/qcow2ova/qcow2ova.go
+++ b/test/e2e/qcow2ova/qcow2ova.go
@@ -15,7 +15,6 @@
 package qcow2ova
 
 import (
-	"io/ioutil"
 	"os"
 
 	"github.com/ppc64le-cloud/pvsadm/pkg/utils"
@@ -37,7 +36,7 @@ var _ = CMDDescribe("pvsadm qcow2ova tests", func() {
 
 	BeforeSuite(func() {
 		var err error
-		image, err = ioutil.TempFile("", "qcow2ova")
+		image, err = os.CreateTemp("", "qcow2ova")
 		Expect(err).NotTo(HaveOccurred())
 		_, err = image.WriteString("some dummy image")
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Use alternate packages such as `io` and `os` as `io/ioutil` has been deprecated.