### PR TITLE
Fix cleanup of spec-files post e2e tests

### DIFF
--- a/test/e2e/sync/sync.go
+++ b/test/e2e/sync/sync.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/IBM-Cloud/bluemix-go/api/resource/resourcev1/management"
@@ -231,14 +232,15 @@ func createObjects() error {
 // Delete Temporarily created local object files and spec file
 func deleteTempFiles() error {
 	klog.Infoln("STEP: Delete created Files")
-	specFolder := strings.Split(SpecFileName, "/")[0]
-	klog.Infoln("Spec folder : ", specFolder)
+	specFolder := filepath.Dir(SpecFileName)
+	klog.Infoln("deleting spec folder:", specFolder)
 
 	err := os.RemoveAll(specFolder)
 	if err != nil {
 		klog.Errorf("ERROR: %v", err)
 	}
 
+	klog.Infoln("deleting object folder:", ObjectsFolderName)
 	err = os.RemoveAll(ObjectsFolderName)
 	if err != nil {
 		klog.Errorf("ERROR: %v", err)


### PR DESCRIPTION
This PR contains fixes to remove all files that have been generated as a part of the e2e tests. 
An error is observed during deletion, as the path is set to ./syncXXXXXXX/files and strings.Split(./syncXXXXXXX/files)[0] returns `.`. filepath.Dir() returns the directory name, which simplifies the retrieval.

https://github.com/ppc64le-cloud/pvsadm/blob/0598d39745dc944f638d73feb9ec0573e0a2212b/test/e2e/sync/sync.go#L234C1-L236C43


```
I0102 17:53:48.800129   33588 sync.go:233] STEP: Delete created Files
I0102 17:53:48.800151   33588 sync.go:235] Spec folder :  .
E0102 17:53:48.800172   33588 sync.go:239] ERROR: RemoveAll .: invalid argument
```

Post filepath.Dir(): 
```
I0103 09:30:29.302944   37256 sync.go:234] STEP: Delete created Files
I0103 09:30:29.302960   37256 sync.go:236] deleting spec folder: spec690497523
I0103 09:30:29.306620   37256 sync.go:243] deleting object folder: ./objects3706579517
```
