### PR TITLE
Add support to list PER enabled DCs/Zones

### DIFF
--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ppc64le-cloud/pvsadm/cmd/get/events"
+	"github.com/ppc64le-cloud/pvsadm/cmd/get/peravailability"
 	"github.com/ppc64le-cloud/pvsadm/cmd/get/ports"
 	"github.com/ppc64le-cloud/pvsadm/pkg"
 )
@@ -31,6 +32,7 @@ var Cmd = &cobra.Command{
 
 func init() {
 	Cmd.AddCommand(events.Cmd)
+	Cmd.AddCommand(peravailability.Cmd)
 	Cmd.AddCommand(ports.Cmd)
 	Cmd.PersistentFlags().StringVarP(&pkg.Options.InstanceID, "instance-id", "i", "", "Instance ID of the PowerVS instance")
 	Cmd.PersistentFlags().StringVarP(&pkg.Options.InstanceName, "instance-name", "n", "", "Instance name of the PowerVS")

--- a/pkg/client/datacenter/datacenter.go
+++ b/pkg/client/datacenter/datacenter.go
@@ -1,0 +1,44 @@
+// Copyright 2021 IBM Corp
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package datacenter
+
+import (
+	"context"
+
+	"github.com/IBM-Cloud/power-go-client/clients/instance"
+	"github.com/IBM-Cloud/power-go-client/ibmpisession"
+	"github.com/IBM-Cloud/power-go-client/power/models"
+)
+
+type Client struct {
+	client     *instance.IBMPIDatacentersClient
+	instanceID string
+}
+
+func NewClient(sess *ibmpisession.IBMPISession, powerinstanceid string) *Client {
+	c := &Client{
+		instanceID: powerinstanceid,
+	}
+	c.client = instance.NewIBMPIDatacenterClient(context.Background(), sess, powerinstanceid)
+	return c
+}
+
+func (c *Client) Get(id string) (*models.Datacenter, error) {
+	return c.client.Get(id)
+}
+
+func (c *Client) GetAll() (*models.Datacenters, error) {
+	return c.client.GetAll()
+}

--- a/pkg/client/pvmclient.go
+++ b/pkg/client/pvmclient.go
@@ -25,6 +25,7 @@ import (
 	"github.com/IBM/go-sdk-core/v5/core"
 
 	"github.com/ppc64le-cloud/pvsadm/pkg"
+	"github.com/ppc64le-cloud/pvsadm/pkg/client/datacenter"
 	"github.com/ppc64le-cloud/pvsadm/pkg/client/dhcp"
 	"github.com/ppc64le-cloud/pvsadm/pkg/client/events"
 	"github.com/ppc64le-cloud/pvsadm/pkg/client/image"
@@ -41,15 +42,17 @@ type PVMClient struct {
 	Region       string
 	Zone         string
 
-	PISession      *ibmpisession.IBMPISession
-	InstanceClient *instance.Client
-	ImgClient      *image.Client
-	JobClient      *job.Client
-	VolumeClient   *volume.Client
-	NetworkClient  *network.Client
-	EventsClient   *events.Client
-	KeyClient      *key.Client
-	DHCPClient     *dhcp.Client
+	PISession *ibmpisession.IBMPISession
+
+	DatacenterClient *datacenter.Client
+	DHCPClient       *dhcp.Client
+	EventsClient     *events.Client
+	ImgClient        *image.Client
+	InstanceClient   *instance.Client
+	JobClient        *job.Client
+	KeyClient        *key.Client
+	NetworkClient    *network.Client
+	VolumeClient     *volume.Client
 }
 
 func NewPVMClient(c *Client, instanceID, instanceName, ep string) (*PVMClient, error) {
@@ -97,13 +100,14 @@ func NewPVMClient(c *Client, instanceID, instanceName, ep string) (*PVMClient, e
 		return nil, err
 	}
 
-	pvmclient.ImgClient = image.NewClient(pvmclient.PISession, instanceID)
-	pvmclient.JobClient = job.NewClient(pvmclient.PISession, instanceID)
-	pvmclient.VolumeClient = volume.NewClient(pvmclient.PISession, instanceID)
-	pvmclient.InstanceClient = instance.NewClient(pvmclient.PISession, instanceID)
-	pvmclient.NetworkClient = network.NewClient(pvmclient.PISession, instanceID)
-	pvmclient.EventsClient = events.NewClient(pvmclient.PISession, instanceID)
-	pvmclient.KeyClient = key.NewClient(pvmclient.PISession, instanceID)
+	pvmclient.DatacenterClient = datacenter.NewClient(pvmclient.PISession, instanceID)
 	pvmclient.DHCPClient = dhcp.NewClient(pvmclient.PISession, instanceID)
+	pvmclient.EventsClient = events.NewClient(pvmclient.PISession, instanceID)
+	pvmclient.ImgClient = image.NewClient(pvmclient.PISession, instanceID)
+	pvmclient.InstanceClient = instance.NewClient(pvmclient.PISession, instanceID)
+	pvmclient.JobClient = job.NewClient(pvmclient.PISession, instanceID)
+	pvmclient.KeyClient = key.NewClient(pvmclient.PISession, instanceID)
+	pvmclient.NetworkClient = network.NewClient(pvmclient.PISession, instanceID)
+	pvmclient.VolumeClient = volume.NewClient(pvmclient.PISession, instanceID)
 	return pvmclient, nil
 }


### PR DESCRIPTION
Changes in this PR:
1. Add support to list PER enabled DCs/Zones, and if the current zone supports PER.
2. Sort packages/Lines of code alphabetically.


```
Kishens-MacBook-Pro  bin : per-availability : ᐅ  ./pvsadm get per-availability --instance-id <redacted>
I0111 13:43:43.702835   50978 root.go:50] Using an API key from IBMCLOUD_API_KEY environment variable
I0111 13:43:46.403958   50978 peravailability.go:67] tok04, where the current instance is present does not support PER.
I0111 13:43:46.403998   50978 peravailability.go:72] The following zones/datacenters have support for PER: [dal10 eu-de-1 eu-de-2 mad02 mad04 sao04 wdc06 wdc07]. More information at https://cloud.ibm.com/docs/overview?topic=overview-locations
```