### PR TITLE
List existing cloud connections from all instances.

### DIFF
--- a/cmd/get/cloudconnections/cloudconnections.go
+++ b/cmd/get/cloudconnections/cloudconnections.go
@@ -1,0 +1,137 @@
+// Copyright 2024 IBM Corp
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudconnections
+
+import (
+	"os"
+	"strings"
+
+	"github.com/IBM-Cloud/power-go-client/ibmpisession"
+	"github.com/IBM/go-sdk-core/v5/core"
+	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
+
+	"github.com/ppc64le-cloud/pvsadm/pkg"
+	"github.com/ppc64le-cloud/pvsadm/pkg/client"
+	"github.com/ppc64le-cloud/pvsadm/pkg/utils"
+)
+
+// Struct to contain the information related to a cloud connection.
+type cloudConnectionDetails struct {
+	name, cloudConnId, state, zone string
+	workspaces                     map[string]struct{}
+}
+
+// Struct to contain the information related to a workspace.
+type workspaceDetails struct {
+	name, guid string
+}
+
+// Map to contain the zone and their associated workspaces it contains at an account level.
+var zoneWorkspaces = make(map[string][]workspaceDetails)
+
+var Cmd = &cobra.Command{
+	Use:   "cloud-connections",
+	Short: "List the existing cloud connections in the account",
+	Long:  "List the existing cloud connections enabled across all workspaces in the account",
+	PreRunE: func(md *cobra.Command, args []string) error {
+		opt := pkg.Options
+		// TODO: The GetAuthenticatorFromEnvironment function seems to refer to "IBMCLOUD_APIKEY" rather than IBMCLOUD_API_KEY as used in the project.
+		// In order to use the resourcecontrollerv2's functionality, the IBMCLOUD_API_KEY is re-exported as IBMCLOUD_APIKEY.
+		os.Setenv("IBMCLOUD_APIKEY", opt.APIKey)
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		opt := pkg.Options
+		c, err := client.NewClientWithEnv(opt.APIKey, opt.Environment, opt.Debug)
+		if err != nil {
+			klog.Errorf("failed to create a session with IBM cloud: %v", err)
+			return err
+		}
+
+		// Retrieve all workspaces that are available in the account.
+		workspaceInstances, err := c.ListWorkspaceInstances()
+		if err != nil {
+			return err
+		}
+		for _, workspaceInstance := range workspaceInstances.Resources {
+			if _, exists := zoneWorkspaces[*workspaceInstance.RegionID]; !exists {
+				zoneWorkspaces[*workspaceInstance.RegionID] = make([]workspaceDetails, 0)
+			}
+			zoneWorkspaces[*workspaceInstance.RegionID] = append(zoneWorkspaces[*workspaceInstance.RegionID], workspaceDetails{name: *workspaceInstance.Name, guid: *workspaceInstance.GUID})
+		}
+		cloudConnections := map[string]cloudConnectionDetails{}
+		authenticator := &core.IamAuthenticator{ApiKey: c.Config.BluemixAPIKey, URL: *c.Config.TokenProviderEndpoint}
+		klog.Info("Listing cloud connections across all workspaces, please wait..")
+		// Create a IBM PI Session per zone and reuse them across the workspaces in the same zone.
+		for workspaceZone, workspaces := range zoneWorkspaces {
+			pvmclientOptions := ibmpisession.IBMPIOptions{Authenticator: authenticator, Debug: pkg.Options.Debug, UserAccount: c.User.Account, Zone: workspaceZone}
+			piSession, err := ibmpisession.NewIBMPISession(&pvmclientOptions)
+			if err != nil {
+				return err
+			}
+			// Iterate over the workspaces available in the zone.
+			for _, workspace := range workspaces {
+				pvmClient, err := client.NewGenericPVMClientWithEnv(c, workspace.guid, workspace.name, opt.Environment, piSession)
+				if err != nil {
+					return err
+				}
+				// Retrieve all the cloud connections that are associated with the workspaces.
+				cloudConnectionResp, err := pvmClient.CloudConnectionClient.GetAll()
+				if err != nil {
+					return err
+				}
+				for _, cloudConnection := range cloudConnectionResp.CloudConnections {
+					// a single CC may used across multiple workspaces, the workspaces need to be grouped accordingly.
+					if _, exists := cloudConnections[*cloudConnection.Name]; !exists {
+						// only add unique CCs and their associated workspaces.
+						ccInstance := cloudConnectionDetails{
+							name:        *cloudConnection.Name,
+							cloudConnId: *cloudConnection.CloudConnectionID,
+							state:       *cloudConnection.LinkStatus,
+							workspaces:  make(map[string]struct{}),
+							zone:        workspaceZone,
+						}
+						ccInstance.workspaces[workspace.name] = struct{}{}
+						cloudConnections[*cloudConnection.Name] = ccInstance
+						continue
+					}
+					// update the map to reuse details of CC, which are used by other workspaces.
+					cloudConnections[*cloudConnection.Name].workspaces[workspace.name] = struct{}{}
+				}
+			}
+		}
+		if len(cloudConnections) > 0 {
+			table := utils.NewTable()
+			table.SetHeader([]string{"Cloud Connection ID", "Name", "State", "Workspaces", "Zone"})
+			for _, cloudConnection := range cloudConnections {
+				workspaces := make([]string, 0, len(cloudConnection.workspaces))
+				for workspace := range cloudConnection.workspaces {
+					workspaces = append(workspaces, workspace)
+				}
+				services := strings.Join(workspaces, ",")
+				table.Append([]string{cloudConnection.cloudConnId, cloudConnection.name, cloudConnection.state, services, cloudConnection.zone})
+			}
+			table.Table.Render()
+			return nil
+		}
+		klog.Info("There are no active cloud connections in this account.")
+		return nil
+	},
+	PostRunE: func(md *cobra.Command, args []string) error {
+		os.Unsetenv("IBMCLOUD_APIKEY")
+		return nil
+	},
+}

--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -17,6 +17,7 @@ package get
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/ppc64le-cloud/pvsadm/cmd/get/cloudconnections"
 	"github.com/ppc64le-cloud/pvsadm/cmd/get/events"
 	"github.com/ppc64le-cloud/pvsadm/cmd/get/peravailability"
 	"github.com/ppc64le-cloud/pvsadm/cmd/get/ports"
@@ -31,6 +32,7 @@ var Cmd = &cobra.Command{
 }
 
 func init() {
+	Cmd.AddCommand(cloudconnections.Cmd)
 	Cmd.AddCommand(events.Cmd)
 	Cmd.AddCommand(peravailability.Cmd)
 	Cmd.AddCommand(ports.Cmd)

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 )
 
 require (
+	github.com/IBM/go-sdk-core v1.1.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
@@ -40,6 +41,7 @@ require (
 	github.com/charmbracelet/lipgloss v0.9.1 // indirect
 	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/containerd/console v1.0.4-0.20230313162750-1ae8d489ac81 // indirect
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -89,6 +91,7 @@ require (
 	golang.org/x/sys v0.17.0 // indirect
 	golang.org/x/term v0.17.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
+	gopkg.in/go-playground/validator.v9 v9.30.0 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/IBM-Cloud/bluemix-go v0.0.0-20220221162715-e08ea9e7c175 h1:FuzMrve2T3
 github.com/IBM-Cloud/bluemix-go v0.0.0-20220221162715-e08ea9e7c175/go.mod h1:r4ZaLtgP9ghpBmnZd77tSjM2LwfOiCLOG6XmCoutnOQ=
 github.com/IBM-Cloud/power-go-client v1.6.0 h1:X+QX+WSF66+aouyaf4r+IeBLXUurAJj9+Bd+vH7G5I0=
 github.com/IBM-Cloud/power-go-client v1.6.0/go.mod h1:0ad5Lcq1utoYVJx0uqooMjCpUaYaK0ItP9QJYtY6k0Y=
+github.com/IBM/go-sdk-core v1.1.0 h1:pV73lZqr9r1xKb3h08c1uNG3AphwoV5KzUzhS+pfEqY=
+github.com/IBM/go-sdk-core v1.1.0/go.mod h1:2pcx9YWsIsZ3I7kH+1amiAkXvLTZtAq9kbxsfXilSoY=
 github.com/IBM/go-sdk-core/v5 v5.16.3 h1:GJI62GNAagX2xeTMpTACIqki5rDVO3YbxzMuIpAXSrQ=
 github.com/IBM/go-sdk-core/v5 v5.16.3/go.mod h1:aojBkkq4HXkOYdn7YZ6ve8cjPWHdcB3tt8v0b9Cbac8=
 github.com/IBM/ibm-cos-sdk-go v1.10.2 h1:IlG7ruBNp10u03FIYvY1qeLoNNHAAAdpFP8h+WmlqM0=
@@ -61,6 +63,7 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
@@ -106,8 +109,10 @@ github.com/go-openapi/validate v0.22.4 h1:5v3jmMyIPKTR8Lv9syBAIRxG6lY0RqeBPB1LKE
 github.com/go-openapi/validate v0.22.4/go.mod h1:qm6O8ZIcPVdSY5219468Jv7kBdGvkiZLPOmqnqTUZ2A=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
 github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
+github.com/go-playground/locales v0.12.1/go.mod h1:IUMDtCfWo/w/mtMfIE/IG2K+Ey3ygWanZIBtBW0W2TM=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
+github.com/go-playground/universal-translator v0.16.0/go.mod h1:1AnU7NaIRDWWzGEKwgtJRd2xk99HeFyHw3yid4rvQIY=
 github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.18.0 h1:BvolUXjp4zuvkZ5YN5t7ebzbhlUtPsPm2S9NAZ5nl9U=
@@ -554,6 +559,9 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
+gopkg.in/go-playground/validator.v9 v9.30.0 h1:Wk0Z37oBmKj9/n+tPyBHZmeL19LaCoK3Qq48VwYENss=
+gopkg.in/go-playground/validator.v9 v9.30.0/go.mod h1:+c9/zcJMFNgbLvly1L1V+PpxWdVbfP1avr/N00E2vyQ=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=

--- a/pkg/client/cloudconnection/cloudconnection.go
+++ b/pkg/client/cloudconnection/cloudconnection.go
@@ -1,0 +1,44 @@
+// Copyright 2024 IBM Corp
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudconnection
+
+import (
+	"context"
+
+	"github.com/IBM-Cloud/power-go-client/clients/instance"
+	"github.com/IBM-Cloud/power-go-client/ibmpisession"
+	"github.com/IBM-Cloud/power-go-client/power/models"
+)
+
+type Client struct {
+	client     *instance.IBMPICloudConnectionClient
+	instanceID string
+}
+
+func NewClient(sess *ibmpisession.IBMPISession, powerinstanceid string) *Client {
+	c := &Client{
+		instanceID: powerinstanceid,
+	}
+	c.client = instance.NewIBMPICloudConnectionClient(context.Background(), sess, powerinstanceid)
+	return c
+}
+
+func (c *Client) Get(id string) (*models.CloudConnection, error) {
+	return c.client.Get(id)
+}
+
+func (c *Client) GetAll() (*models.CloudConnections, error) {
+	return c.client.GetAll()
+}

--- a/pkg/client/environments.go
+++ b/pkg/client/environments.go
@@ -17,6 +17,8 @@ package client
 import (
 	"errors"
 	"os"
+
+	"github.com/IBM-Cloud/power-go-client/ibmpisession"
 )
 
 const DefaultEnv = "prod"
@@ -56,6 +58,14 @@ func NewPVMClientWithEnv(c *Client, instanceID, instanceName, env string) (*PVMC
 		return nil, err
 	}
 	return NewPVMClient(c, instanceID, instanceName, e["PIEndpoint"])
+}
+
+func NewGenericPVMClientWithEnv(c *Client, instanceID, instanceName, env string, piSession *ibmpisession.IBMPISession) (*PVMClient, error) {
+	e, err := GetEnvironment(env)
+	if err != nil {
+		return nil, err
+	}
+	return NewGenericPVMClient(c, instanceID, instanceName, e["PIEndpoint"], piSession)
 }
 
 func NewClientWithEnv(apikey, env string, debug bool) (*Client, error) {


### PR DESCRIPTION
Fixes: #518 

Changes in this PR:
1. List all cloud connections that are existent in an account.
```
Kishens-MacBook-Pro bin : list-cc :ᐅ  ./pvsadm get cloud-connections --instance-id 2313fc87-f7e9-4df6-969e-c0d37b8818a3
I0112 19:14:42.567381   91239 root.go:50] Using an API key from IBMCLOUD_API_KEY environment variable
I0112 19:14:48.005075   91239 cloudconnections.go:50] Listing cloud connections across all services, please wait..
+--------------------------------------+------------------------------------------+-------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|        CLOUD CONNECTION ID           |                   NAME                   |   STATE     |                                                                             SERVICE NAME                                                                              |
+--------------------------------------+------------------------------------------+-------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| 3984e503-0333-4ac9-ad48-55c2cd28f3c2 | hypershift-clusterbot-ci-lon-cc          | established | hypershift-clusterbot-ci-lon-pvs                                                                                                                                      |
| f072a4fb-cdfd-4cac-ba06-0c6dc79d7b65 | rh-upstream-hypershift-powervs-ci-cc     | established | rh-upstream-hypershift-powervs-ci-pvs,rh-upstream-hypershift-powervs-ci-e2e-pvs                                                                                       |
| aa50ffa5-1d38-4f30-8fb1-26e1c9023b12 | rh-upstream-hypershift-powervs-ci-e2e-cc | established | rh-upstream-hypershift-powervs-ci-pvs,rh-upstream-hypershift-powervs-ci-e2e-pvs                                                                                       |
| c0b71835-bb43-49b8-af78-0fddaac5cf95 | rh-upstream-hypershift-agent-ci-cc       | established | rh-upstream-hypershift-agent-ci,hypershift-ci-20230518075033-infra-pvs,keerthanaworkspace,test-hyp-pvs,hyp-dhar-tok-4-nodepool,rh-upstream-hypershift-cluster-bot-pvs |
| 332becce-9c97-43c5-adf6-affdae46256d | rh-upstream-hypershift-cluster-bot-cc    | established | test-hyp-pvs,hyp-dhar-tok-4-nodepool,rh-upstream-hypershift-cluster-bot-pvs,rh-upstream-hypershift-agent-ci,hypershift-ci-20230518075033-infra-pvs,keerthanaworkspace |
+--------------------------------------+------------------------------------------+-------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```
