### PR TITLE
Beautify output for dhcpserver commands

### DIFF
--- a/cmd/dhcpserver/list.go
+++ b/cmd/dhcpserver/list.go
@@ -48,8 +48,24 @@ var listCmd = &cobra.Command{
 			return fmt.Errorf("failed to get the networks, err: %v", err)
 		}
 
+		if len(dhcpservers) == 0 {
+			klog.Info("There are no DHCP servers associated with the instance id provided.")
+			return nil
+		}
+
 		table := utils.NewTable()
-		table.Render(dhcpservers, nil)
+		table.SetHeader([]string{"ID", "Network ID", "Network Name", "Status"})
+		for _, dhcpserver := range dhcpservers {
+			if dhcpserver.Network.ID == nil || dhcpserver.Network.Name == nil {
+				// just in case, if the network is not ready, and the DHCP status reports as BUILD.
+				// printing the available information must suffice.
+				table.Append([]string{*dhcpserver.ID, "", "", *dhcpserver.Status})
+				continue
+			}
+			table.Append([]string{*dhcpserver.ID, *dhcpserver.Network.ID, *dhcpserver.Network.Name, *dhcpserver.Status})
+		}
+		table.Table.Render()
 		return nil
+
 	},
 }


### PR DESCRIPTION
Fixes: #590

```
Kishens-MacBook-Pro➜  bin : pretty-dhcp ✘:  ./pvsadm dhcpserver list --instance-id 549cae6a-d568-4c56-9977-1acc084bd4fa
I0416 18:53:46.368742   85059 root.go:50] Using an API key from IBMCLOUD_API_KEY environment variable
+--------------------------------------+--------------------------------------+----------------------------------------------------+--------+
|                  ID                  |              NETWORK ID              |                    NETWORK NAME                    | STATUS |
+--------------------------------------+--------------------------------------+----------------------------------------------------+--------+
| b8b0ae74-9b06-44fa-8ab7-d723db9bdb25 | 12ba2f3e-135e-4659-ac40-644126f2ddcc | DHCPSERVERbdaab417b86d4c0f927bf130c2a6e114_Private | ACTIVE |
+--------------------------------------+--------------------------------------+----------------------------------------------------+--------+


The get command does not contain the Network ID field, as the same is available from `list` command

Kishens-MacBook-Pro➜  bin : pretty-dhcp ✘ : ./pvsadm dhcpserver get --instance-id 549cae6a-d568-4c56-9977-1acc084bd4fa --id b8b0ae74-9b06-44fa-8ab7-d723db9bdb25
I0416 18:53:57.506791   85095 root.go:50] Using an API key from IBMCLOUD_API_KEY environment variable
+--------------------------------------+--------------------------------+----------------------------------------------------+--------+
|                  ID                  |            IP - MAC            |                    NETWORK NAME                    | STATUS |
+--------------------------------------+--------------------------------+----------------------------------------------------+--------+
| b8b0ae74-9b06-44fa-8ab7-d723db9bdb25 | 192.168.0.10 -                 | DHCPSERVERbdaab417b86d4c0f927bf130c2a6e114_Private | ACTIVE |
|                                      | fa:16:3e:87:b1:64              |                                                    |        |
+--------------------------------------+--------------------------------+----------------------------------------------------+--------+


Kishens-MacBook-Pro➜  bin : pretty-dhcp ✘   ./pvsadm dhcpserver list --instance-id 9a344d8e-49c6-4307-9303-471c8bd1844a
I0416 19:17:25.934982   85957 root.go:50] Using an API key from IBMCLOUD_API_KEY environment variable
I0416 19:17:30.385736   85957 list.go:60] There are no DHCP servers associated with the instance id provided.
```