### PR TITLE
Free up loopdevice after image is built

### DIFF
--- a/cmd/image/qcow2ova/prep/loop.go
+++ b/cmd/image/qcow2ova/prep/loop.go
@@ -29,15 +29,6 @@ import (
 
 const losetupCMD = "losetup"
 
-func findFreeLoop(file string) (string, error) {
-	exitcode, out, err := utils.RunCMD(losetupCMD, "-f")
-	if exitcode != 0 {
-		return "", fmt.Errorf("failed to find an unused loop device, exitcode: %d, stdout: %s, err: %s", exitcode, out, err)
-	}
-
-	return strings.TrimSpace(out), nil
-}
-
 // setupLoop allocates the free loop device for the backing store
 func setupLoop(file string) (string, error) {
 	exitcode, out, err := utils.RunCMD(losetupCMD, "-f", "--show", file)
@@ -46,6 +37,14 @@ func setupLoop(file string) (string, error) {
 	}
 
 	return strings.TrimSpace(out), nil
+}
+
+func removeLoop(loopPath string) error {
+	exitcode, stdout, stderr := utils.RunCMD(losetupCMD, "-d", loopPath)
+	if exitcode != 0 {
+		return fmt.Errorf("failed to remove loop device: %s, exitcode: %d, stdout: %s, err: %s", loopPath, exitcode, stdout, stderr)
+	}
+	return nil
 }
 
 func partprobe(device string) error {

--- a/cmd/image/qcow2ova/prep/prepare.go
+++ b/cmd/image/qcow2ova/prep/prepare.go
@@ -39,6 +39,7 @@ func prepare(mnt, volume, dist, rhnuser, rhnpasswd, rootpasswd string) error {
 	if err != nil {
 		return err
 	}
+	defer removeLoop(lo)
 
 	err = partprobe(lo)
 	if err != nil {


### PR DESCRIPTION
Fixes: https://github.com/ppc64le-cloud/pvsadm/issues/591

Before image creation: 
```
[root@pvsadm-tester1 bin]# df -h /
Filesystem           Size  Used Avail Use% Mounted on
/dev/mapper/cl-root  233G   11G  223G   5% /
```
After image creation:

```
[root@pvsadm-tester1 bin]# df -h /
Filesystem           Size  Used Avail Use% Mounted on
/dev/mapper/cl-root  233G   17G  217G   7% /
```

After deleting image that was created.

```
[root@pvsadm-tester1 bin]# df -h /
Filesystem           Size  Used Avail Use% Mounted on
/dev/mapper/cl-root  233G   15G  219G   7% /
```
___
**With Fix**

Before Image creation

```
 [root@pvsadm-tester1 bin]# df -h /
Filesystem           Size  Used Avail Use% Mounted on
/dev/mapper/cl-root  233G   11G  223G   5% /
```

After image creation

```
[root@pvsadm-tester1 bin]# df -h /
Filesystem           Size  Used Avail Use% Mounted on
/dev/mapper/cl-root  233G   13G  221G   6% /  
```

After deleting the image that was created. 
(Avail space before image creation = Avail space after image creation)
```
[root@pvsadm-tester1 bin]# df -h /
Filesystem           Size  Used Avail Use% Mounted on
/dev/mapper/cl-root  233G   11G  223G   5% /
```

The built image was tested on PowerVS to ensure its functioning. 