### PR TITLE
Add bucket exists check before checking object exists while uploading image

### DIFF
--- a/cmd/image/upload/upload.go
+++ b/cmd/image/upload/upload.go
@@ -129,6 +129,11 @@ pvsadm image upload --bucket bucket1320 -f centos-8-latest.ova.gz --bucket-regio
 			if err != nil {
 				return err
 			}
+
+			if !bucketExists {
+				klog.Infof("Bucket %s not found in the instance %s provided", opt.BucketName, opt.InstanceName)
+			}
+
 		} else if len(instances) != 0 {
 			//check for bucket across the instances
 			for instanceName := range instances {
@@ -210,17 +215,16 @@ pvsadm image upload --bucket bucket1320 -f centos-8-latest.ova.gz --bucket-regio
 		if err != nil {
 			return err
 		}
-
-		objectExists, err := s3Cli.CheckIfObjectExists(opt.BucketName, opt.ObjectName)
-		if err != nil {
-			return err
-		}
-		if objectExists {
-			return fmt.Errorf("%s object already exists in the %s bucket", opt.ObjectName, opt.BucketName)
-		}
-
-		//Create a new bucket
-		if !bucketExists {
+		if bucketExists {
+			objectExists, err := s3Cli.CheckIfObjectExists(opt.BucketName, opt.ObjectName)
+			if err != nil {
+				return err
+			}
+			if objectExists {
+				return fmt.Errorf("%s object already exists in the %s bucket", opt.ObjectName, opt.BucketName)
+			}
+		} else {
+			//Create a new bucket
 			klog.Infof("Creating a new bucket %s", opt.BucketName)
 			s3Cli, err = client.NewS3Client(bxCli, opt.InstanceName, opt.Region)
 			if err != nil {


### PR DESCRIPTION
Added bucket exists check before verifying whether the object exists when cos-instance-name is provided.


```
./pvsadm image upload -b power1-oss-bucket -f karthik-centos-8.ova.gz -n New-keer-cos -r us-south
I0507 22:46:33.462260   60503 upload.go:134] Bucket power1-oss-bucket not found in the instance New-keer-cos provided
I0507 22:46:35.949740   60503 upload.go:228] Creating a new bucket power1-oss-bucket
I0507 22:46:40.552761   60503 s3client.go:209] Waiting for bucket power1-oss-bucket to be created.
I0507 22:46:40.962257   60503 s3client.go:269] uploading the file karthik-centos-8.ova.gz
```