### PR TITLE
Fix diskspace of /   issue of rhel 9.* images.

### DIFF
--- a/cmd/image/qcow2ova/prep/templates.go
+++ b/cmd/image/qcow2ova/prep/templates.go
@@ -157,11 +157,13 @@ write_files:
       set -e
       for i in /dev/sd[a-z]; do
         partprobe $i || true
-        growpart $i 2 || true
+        part=$(partprobe -s $i | awk '{print $NF}')
+        growpart $i $part || true
       done
       for i in /dev/mapper/mpath[a-z]; do
         partprobe $i || true
-        growpart $i 2 || true
+        part=$(partprobe -s $i | awk '{print $NF}')
+        growpart $i $part || true
       done
 
 runcmd:


### PR DESCRIPTION
Fix for https://github.com/ppc64le-cloud/pvsadm/issues/620

Disk space before the fix in rhel 9.4:

```
Create an account or view all your systems at https://red.ht/insights-dashboard
[root@newvm ~]# df -h
Filesystem           Size  Used Avail Use% Mounted on
devtmpfs             4.0M     0  4.0M   0% /dev
tmpfs                751M     0  751M   0% /dev/shm
tmpfs                301M   32M  270M  11% /run
/dev/mapper/mpatha3   10G  2.0G  8.0G  20% /
/dev/mapper/mpatha2  960M  296M  665M  31% /boot
tmpfs                151M     0  151M   0% /run/user/0
```

Disk space after the fix:

```
[root@testvm ~]# df -h
Filesystem           Size  Used Avail Use% Mounted on
devtmpfs             4.0M     0  4.0M   0% /dev
tmpfs                751M     0  751M   0% /dev/shm
tmpfs                301M   15M  286M   5% /run
/dev/mapper/mpatha3  119G  2.8G  117G   3% /
/dev/mapper/mpatha2  960M  296M  665M  31% /boot
tmpfs                151M     0  151M   0% /run/user/0
```



