### PR TITLE
Cleanup code and docs

### DIFF
--- a/cmd/dhcp-sync/dhcp-sync.go
+++ b/cmd/dhcp-sync/dhcp-sync.go
@@ -172,7 +172,7 @@ var Cmd = &cobra.Command{
 
 		watcher, err := fsnotify.NewWatcher()
 		if err != nil {
-			klog.Fatal(err)
+			klog.Fatalf("cannot create a new fsNotify watcher: %v", err)
 		}
 		defer watcher.Close()
 
@@ -184,7 +184,7 @@ var Cmd = &cobra.Command{
 					if !ok {
 						return
 					}
-					klog.V(2).Infof("event: %v", event)
+					klog.V(2).Infof("received an fsWatcher event: %v", event)
 					if event.Op&fsnotify.Write == fsnotify.Write {
 						klog.V(2).Infof("%s has been modified, proceeding to restart dhcpd service", event.Name)
 						exitcode, out, err := utils.RunCMD("systemctl", "restart", "dhcpd")
@@ -196,14 +196,14 @@ var Cmd = &cobra.Command{
 					if !ok {
 						return
 					}
-					klog.Error("error:", err)
+					klog.Errorf("received an fsWatcher error: %v", err)
 				}
 			}
 		}()
 
 		err = watcher.Add(file)
 		if err != nil {
-			klog.Fatal(err)
+			klog.Fatalf("cannot sync DHCP server: %v", err)
 		}
 		<-done
 		return nil

--- a/cmd/get/peravailability/peravailability.go
+++ b/cmd/get/peravailability/peravailability.go
@@ -54,7 +54,7 @@ var Cmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		supportsPER := false
+		var supportsPER bool
 		for _, datacenter := range ret.Datacenters {
 			if datacenter.Capabilities[powerEdgeRouter] {
 				perEnabledRegions = append(perEnabledRegions, *datacenter.Location.Region)

--- a/cmd/image/import/import.go
+++ b/cmd/image/import/import.go
@@ -71,7 +71,7 @@ pvsadm image import --help for information
 # Set the API key or feed the --api-key commandline argument
 export IBMCLOUD_API_KEY=<IBM_CLOUD_API_KEY>
 
-# To Import the imge across the two different IBM account use accesskey and secretkey options
+# To Import the image across the two different IBM account use accesskey and secretkey options
 
 # To Import the image from public bucket use public-bucket option
 
@@ -97,10 +97,8 @@ pvsadm image import -n upstream-core-lon04 -b <BUCKETNAME> --object rhel-83-1003
 			return fmt.Errorf("--workspace-name or --workspace-id required")
 		}
 
-		case1 := pkg.ImageCMDOptions.AccessKey == "" && pkg.ImageCMDOptions.SecretKey != ""
-		case2 := pkg.ImageCMDOptions.AccessKey != "" && pkg.ImageCMDOptions.SecretKey == ""
-
-		if case1 || case2 {
+		// ensure that both, the AccessKey and SecretKey are either both set or unset
+		if (len(pkg.ImageCMDOptions.AccessKey) > 0) != (len(pkg.ImageCMDOptions.SecretKey) > 0) {
 			return fmt.Errorf("required both --accesskey and --secretkey values")
 		}
 		return nil

--- a/cmd/image/sync/sync.go
+++ b/cmd/image/sync/sync.go
@@ -43,8 +43,8 @@ type InstanceItem struct {
 
 // sync constants
 const (
-	serviceType     = "cloud-object-storage"
-	noOfcopyWorkers = 20
+	serviceType = "cloud-object-storage"
+	maxWorkers  = 20
 )
 
 // Worker method to copy object from source bucket to target bucket
@@ -102,8 +102,8 @@ func calculateChannels(spec []pkg.Spec, instanceList []InstanceItem) (int, error
 			return 0, err
 		}
 
-		noOfTargets := len(item.Target)
-		totalChannelsForSrc := noOfTargets * len(selectedObjects)
+		numTargets := len(item.Target)
+		totalChannelsForSrc := numTargets * len(selectedObjects)
 		totalChannels = totalChannels + totalChannelsForSrc
 	}
 	return totalChannels, nil
@@ -186,8 +186,8 @@ func syncObjects(spec []pkg.Spec, instanceList []InstanceItem) error {
 	// Creating workers and channels
 	copyJobs := make(chan copyWorkload, totalChannels)
 	results := make(chan bool, totalChannels)
-	for w := 1; w <= noOfcopyWorkers; w++ {
-		go copyWorker(copyJobs, results, w)
+	for worker := 1; worker <= maxWorkers; worker++ {
+		go copyWorker(copyJobs, results, worker)
 	}
 
 	// Copy objects

--- a/cmd/image/sync/sync_test.go
+++ b/cmd/image/sync/sync_test.go
@@ -32,9 +32,9 @@ import (
 
 // Test case constants
 const (
-	noOfSources          = 3
-	noOfTargetsPerSource = 3
-	noOfObjects          = 200
+	numSources          = 3
+	numTargetsPerSource = 3
+	numObjects          = 200
 )
 
 func TestCalculateChannels(t *testing.T) {
@@ -47,8 +47,8 @@ func TestCalculateChannels(t *testing.T) {
 		mockSyncClient := mocksync.NewMockSyncClient(mockCtrl)
 
 		// test case setup
-		mockSetBucketLocationConstraint(mockSyncClient, noOfSources, true, "")
-		mockSetSelectedObjects(mockSyncClient, noOfObjects, noOfSources)
+		mockSetBucketLocationConstraint(mockSyncClient, numSources, true, "")
+		mockSetSelectedObjects(mockSyncClient, numObjects, numSources)
 
 		// generating spec slice
 		spec := mockCreateSpec()
@@ -59,7 +59,7 @@ func TestCalculateChannels(t *testing.T) {
 		// test case verification section
 		totalChannels, err := calculateChannels(spec, instanceList)
 		require.NoError(t, err, "Error calculating channels")
-		assert.Equal(t, noOfObjects*noOfSources*noOfTargetsPerSource, totalChannels)
+		assert.Equal(t, numObjects*numSources*numTargetsPerSource, totalChannels)
 	})
 }
 
@@ -129,11 +129,11 @@ func TestSync(t *testing.T) {
 				return mockCreateSpec()
 			},
 			setup: func(mockSyncClient *mocksync.MockSyncClient) {
-				mockSetBucketLocationConstraint(mockSyncClient, noOfSources, true, "")
-				mockSetSelectedObjects(mockSyncClient, noOfObjects, noOfSources)
-				mockSetSelectedObjects(mockSyncClient, noOfObjects, noOfSources)
-				mockSetBucketLocationConstraint(mockSyncClient, noOfSources*noOfTargetsPerSource, true, "")
-				mockSetCopyObjectToBucket(mockSyncClient, noOfObjects*noOfSources*noOfTargetsPerSource, "")
+				mockSetBucketLocationConstraint(mockSyncClient, numSources, true, "")
+				mockSetSelectedObjects(mockSyncClient, numObjects, numSources)
+				mockSetSelectedObjects(mockSyncClient, numObjects, numSources)
+				mockSetBucketLocationConstraint(mockSyncClient, numSources*numTargetsPerSource, true, "")
+				mockSetCopyObjectToBucket(mockSyncClient, numObjects*numSources*numTargetsPerSource, "")
 
 			},
 			expectedError: "",
@@ -152,10 +152,10 @@ func TestSync(t *testing.T) {
 				return mockCreateSpec()
 			},
 			setup: func(mockSyncClient *mocksync.MockSyncClient) {
-				mockSetBucketLocationConstraint(mockSyncClient, noOfSources, true, "")
-				mockSetSelectedObjects(mockSyncClient, 0, noOfSources)
-				mockSetSelectedObjects(mockSyncClient, 0, noOfSources)
-				mockSetBucketLocationConstraint(mockSyncClient, noOfSources*noOfTargetsPerSource, true, "")
+				mockSetBucketLocationConstraint(mockSyncClient, numSources, true, "")
+				mockSetSelectedObjects(mockSyncClient, 0, numSources)
+				mockSetSelectedObjects(mockSyncClient, 0, numSources)
+				mockSetBucketLocationConstraint(mockSyncClient, numSources*numTargetsPerSource, true, "")
 				mockSetCopyObjectToBucket(mockSyncClient, 0, "")
 
 			},
@@ -193,9 +193,9 @@ func TestSync(t *testing.T) {
 				return mockCreateSpec()
 			},
 			setup: func(mockSyncClient *mocksync.MockSyncClient) {
-				mockSetBucketLocationConstraint(mockSyncClient, noOfSources, true, "")
-				mockSetSelectedObjects(mockSyncClient, noOfObjects, noOfSources)
-				mockSetSelectedObjects(mockSyncClient, noOfObjects, 1)
+				mockSetBucketLocationConstraint(mockSyncClient, numSources, true, "")
+				mockSetSelectedObjects(mockSyncClient, numObjects, numSources)
+				mockSetSelectedObjects(mockSyncClient, numObjects, 1)
 				mockSetBucketLocationConstraint(mockSyncClient, 1, false, "Failed to verify bucket location constriant")
 			},
 			expectedError: "bucket location constraint verification failed",
@@ -234,11 +234,11 @@ func TestSync(t *testing.T) {
 
 func mockCreateInstances(mockSyncClient *mocksync.MockSyncClient) []InstanceItem {
 	var instanceList []InstanceItem
-	for i := 0; i < noOfSources; i++ {
+	for i := 0; i < numSources; i++ {
 		instance := InstanceItem{}
 		instance.Source = mockSyncClient
 
-		for j := 0; j < noOfTargetsPerSource; j++ {
+		for j := 0; j < numTargetsPerSource; j++ {
 			instance.Target = append(instance.Target, mockSyncClient)
 		}
 		instanceList = append(instanceList, instance)
@@ -249,8 +249,8 @@ func mockCreateInstances(mockSyncClient *mocksync.MockSyncClient) []InstanceItem
 func mockCreateSpec() []pkg.Spec {
 	klog.V(1).Info("STEP: Generating Spec")
 	specSlice := make([]pkg.Spec, 0)
-	for i := 0; i < noOfSources; i++ {
-		specSlice = append(specSlice, utils.GenerateSpec(noOfTargetsPerSource))
+	for i := 0; i < numSources; i++ {
+		specSlice = append(specSlice, utils.GenerateSpec(numTargetsPerSource))
 	}
 	return specSlice
 }

--- a/cmd/image/upload/upload.go
+++ b/cmd/image/upload/upload.go
@@ -28,8 +28,8 @@ import (
 
 const (
 	ServiceType              = "cloud-object-storage"
-	UseExistingPromptMessage = "Would You Like to use Available COS Instance for creating bucket?"
-	CreatePromptMessage      = "Would you like to create new COS Instance?"
+	UseExistingPromptMessage = "Would you like to use an existing COS Instance for creating bucket?"
+	CreatePromptMessage      = "Would you like to create a new COS Instance?"
 	ResourceGroupAPIRegion   = "global"
 )
 
@@ -68,10 +68,8 @@ pvsadm image upload --bucket bucket1320 -f centos-8-latest.ova.gz --bucket-regio
 			return fmt.Errorf("image upload in test/staging env storage bucket is not supported")
 		}
 
-		case1 := pkg.ImageCMDOptions.AccessKey == "" && pkg.ImageCMDOptions.SecretKey != ""
-		case2 := pkg.ImageCMDOptions.AccessKey != "" && pkg.ImageCMDOptions.SecretKey == ""
-
-		if case1 || case2 {
+		// ensure that both, the AccessKey and SecretKey are set.
+		if (len(pkg.ImageCMDOptions.AccessKey) > 0) != (len(pkg.ImageCMDOptions.SecretKey) > 0) {
 			return fmt.Errorf("required both --accesskey and --secretkey values")
 		}
 
@@ -79,7 +77,7 @@ pvsadm image upload --bucket bucket1320 -f centos-8-latest.ova.gz --bucket-regio
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var s3Cli *client.S3Client
-		var bucketExists bool = false
+		var bucketExists bool
 		var apikey string = pkg.Options.APIKey
 		opt := pkg.ImageCMDOptions
 
@@ -88,7 +86,7 @@ pvsadm image upload --bucket bucket1320 -f centos-8-latest.ova.gz --bucket-regio
 		}
 
 		if pkg.ImageCMDOptions.AccessKey != "" && pkg.ImageCMDOptions.SecretKey != "" {
-			s3Cli, err := client.NewS3Clientwithkeys(pkg.ImageCMDOptions.AccessKey, pkg.ImageCMDOptions.SecretKey, opt.Region)
+			s3Cli, err := client.NewS3ClientWithKeys(pkg.ImageCMDOptions.AccessKey, pkg.ImageCMDOptions.SecretKey, opt.Region)
 			if err != nil {
 				return err
 			}

--- a/cmd/purge/images/images.go
+++ b/cmd/purge/images/images.go
@@ -29,8 +29,8 @@ const deletePromptMessage = "Deleting all the above images, images can't be clai
 
 var Cmd = &cobra.Command{
 	Use:   "images",
-	Short: "Purge the powervs images",
-	Long: `Purge the powervs images!
+	Short: "Purge the PowerVS images",
+	Long: `Purge the PowerVS images!
 pvsadm purge --help for information
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/purge/networks/networks.go
+++ b/cmd/purge/networks/networks.go
@@ -33,8 +33,8 @@ var (
 
 var Cmd = &cobra.Command{
 	Use:   "networks",
-	Short: "Purge the powervs networks",
-	Long: `Purge the powervs networks!
+	Short: "Purge the PowerVS networks",
+	Long: `Purge the PowerVS networks!
 pvsadm purge --help for information
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/purge/purge.go
+++ b/cmd/purge/purge.go
@@ -29,8 +29,8 @@ import (
 
 var Cmd = &cobra.Command{
 	Use:   "purge",
-	Short: "Purge the powervs resources",
-	Long: `Purge the powervs resources
+	Short: "Purge the PowerVS resources",
+	Long: `Purge the PowerVS resources
 
 # Set the API key or feed the --api-key commandline argument
 export IBMCLOUD_API_KEY=<IBM_CLOUD_API_KEY>

--- a/cmd/purge/vms/vms.go
+++ b/cmd/purge/vms/vms.go
@@ -30,8 +30,8 @@ const deletePromptMessage = "Deleting all the above instances, instances can't b
 
 var Cmd = &cobra.Command{
 	Use:   "vms",
-	Short: "Purge the powervs vms",
-	Long: `Purge the powervs vms!
+	Short: "Purge the PowerVS vms",
+	Long: `Purge the PowerVS vms!
 pvsadm purge --help for information
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/purge/volumes/volumes.go
+++ b/cmd/purge/volumes/volumes.go
@@ -32,8 +32,8 @@ const deletePromptMessage = "Deleting all the volumes in available state, volume
 
 var Cmd = &cobra.Command{
 	Use:   "volumes",
-	Short: "Purge the powervs volumes",
-	Long: `Deletes all the volumes for the powervs instance which are in available state(not attached to any instances)
+	Short: "Purge the PowerVS volumes",
+	Long: `Deletes all the volumes for the PowerVS instance which are in available state(not attached to any instances)
 pvsadm purge --help for information
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,7 +39,7 @@ import (
 
 var rootCmd = &cobra.Command{
 	Use:   "pvsadm",
-	Short: "pvsadm is a command for managing powervs infra",
+	Short: "pvsadm is a command line tool for managing IBM Cloud PowerVS infrastructure",
 	Long: `Power Systems Virtual Server projects deliver flexible compute capacity for Power Systems workloads.
 Integrated with the IBM Cloud platform for on-demand provisioning.
 

--- a/docs/How to Import Image to PowerVS Instance.md
+++ b/docs/How to Import Image to PowerVS Instance.md
@@ -1,9 +1,9 @@
 # Overview
-This guide talks about how to import image to PowerVs workspace using pvsadm.
+This guide talks about how to import image to PowerVS workspace using pvsadm.
 
 # Prerequisite
 - pvsadm tool
-- IBMCLOUD_API_KEY. [How to create api key](https://cloud.ibm.com/docs/account?topic=account-userapikey#create_user_key)
+- IBMCLOUD_API_KEY. [How to create API key](https://cloud.ibm.com/docs/account?topic=account-userapikey#create_user_key)
 - S3 BucketName, Bucket Region, ObjectName
 - PowerVS Workspace Name/PowerVS Workspace ID.
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -194,7 +194,7 @@ func (c *Client) ListServiceInstances(serviceType string) (map[string]string, er
 	return instances, nil
 }
 
-// func ListWorkspaceInstances is used to retrieve serviceInstances aloong with their regions.
+// func ListWorkspaceInstances is used to retrieve serviceInstances along with their regions.
 func (c *Client) ListWorkspaceInstances() (*resourcecontrollerv2.ResourceInstancesList, error) {
 	auth, err := core.GetAuthenticatorFromEnvironment(serviceIBMCloud)
 
@@ -213,7 +213,7 @@ func (c *Client) ListWorkspaceInstances() (*resourcecontrollerv2.ResourceInstanc
 	}
 	workspaces, _, err := c.ResouceControllerClient.ListResourceInstances(listServiceInstanceOptions)
 	if err != nil {
-		klog.Errorf("error while listing Resource Instances: %+v", err)
+		klog.Errorf("error while listing resource instances: %+v", err)
 		return nil, err
 	}
 	return workspaces, nil
@@ -292,8 +292,8 @@ func (c *Client) CreateServiceInstance(instanceName, serviceName, servicePlan, r
 		return "", err
 	}
 
-	klog.Infof("Resource service Instance Details :%v", serviceInstance)
-	klog.Infof("Resource service InstanceID :%v", serviceInstance.Crn.ServiceInstance)
+	klog.Infof("Resource service instance details :%v", serviceInstance)
+	klog.Infof("Resource service instanceID :%v", serviceInstance.Crn.ServiceInstance)
 
 	return serviceInstance.Crn.ServiceInstance, nil
 }

--- a/pkg/client/cloudconnection/cloudconnection.go
+++ b/pkg/client/cloudconnection/cloudconnection.go
@@ -28,11 +28,10 @@ type Client struct {
 }
 
 func NewClient(sess *ibmpisession.IBMPISession, powerinstanceid string) *Client {
-	c := &Client{
+	return &Client{
 		instanceID: powerinstanceid,
+		client:     instance.NewIBMPICloudConnectionClient(context.Background(), sess, powerinstanceid),
 	}
-	c.client = instance.NewIBMPICloudConnectionClient(context.Background(), sess, powerinstanceid)
-	return c
 }
 
 func (c *Client) Get(id string) (*models.CloudConnection, error) {

--- a/pkg/client/datacenter/datacenter.go
+++ b/pkg/client/datacenter/datacenter.go
@@ -28,11 +28,10 @@ type Client struct {
 }
 
 func NewClient(sess *ibmpisession.IBMPISession, powerinstanceid string) *Client {
-	c := &Client{
+	return &Client{
 		instanceID: powerinstanceid,
+		client:     instance.NewIBMPIDatacenterClient(context.Background(), sess, powerinstanceid),
 	}
-	c.client = instance.NewIBMPIDatacenterClient(context.Background(), sess, powerinstanceid)
-	return c
 }
 
 func (c *Client) Get(id string) (*models.Datacenter, error) {

--- a/pkg/client/dhcp/dhcp.go
+++ b/pkg/client/dhcp/dhcp.go
@@ -29,12 +29,11 @@ type Client struct {
 }
 
 func NewClient(sess *ibmpisession.IBMPISession, powerinstanceid string) *Client {
-	c := &Client{
+	return &Client{
 		session:    sess,
 		instanceID: powerinstanceid,
+		client:     instance.NewIBMPIDhcpClient(context.Background(), sess, powerinstanceid),
 	}
-	c.client = instance.NewIBMPIDhcpClient(context.Background(), sess, powerinstanceid)
-	return c
 }
 
 func (c *Client) Get(id string) (*models.DHCPServerDetail, error) {

--- a/pkg/client/environments.go
+++ b/pkg/client/environments.go
@@ -23,7 +23,7 @@ import (
 
 const DefaultEnv = "prod"
 
-var EnvironmentNotFound = errors.New("environment not found")
+var ErrEnvironmentNotFound = errors.New("error environment not found")
 
 var Environments = map[string]map[string]string{
 	"test": {
@@ -47,7 +47,7 @@ func ListEnvironments() (keys []string) {
 
 func GetEnvironment(env string) (map[string]string, error) {
 	if _, ok := Environments[env]; !ok {
-		return nil, EnvironmentNotFound
+		return nil, ErrEnvironmentNotFound
 	}
 	return Environments[env], nil
 }

--- a/pkg/client/environments_test.go
+++ b/pkg/client/environments_test.go
@@ -64,7 +64,7 @@ func TestGetEnvironment(t *testing.T) {
 			"valid environment - prod",
 			args{"fake"},
 			nil,
-			EnvironmentNotFound,
+			ErrEnvironmentNotFound,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/client/events/events.go
+++ b/pkg/client/events/events.go
@@ -30,12 +30,11 @@ type Client struct {
 }
 
 func NewClient(sess *ibmpisession.IBMPISession, powerinstanceid string) *Client {
-	c := &Client{
+	return &Client{
 		session:    sess,
 		instanceID: powerinstanceid,
 		client:     sess.Power.PCloudEvents,
 	}
-	return c
 }
 
 func (c *Client) GetPcloudEventsGetsince(since time.Duration) (*p_cloud_events.PcloudEventsGetqueryOK, error) {

--- a/pkg/client/image/image.go
+++ b/pkg/client/image/image.go
@@ -34,13 +34,12 @@ type Client struct {
 }
 
 func NewClient(sess *ibmpisession.IBMPISession, powerinstanceid string) *Client {
-	c := &Client{
+	return &Client{
 		session:    sess,
 		instanceID: powerinstanceid,
+		client:     instance.NewIBMPIImageClient(context.Background(), sess, powerinstanceid),
+		jobclient:  instance.NewIBMPIJobClient(context.Background(), sess, powerinstanceid),
 	}
-	c.client = instance.NewIBMPIImageClient(context.Background(), sess, powerinstanceid)
-	c.jobclient = instance.NewIBMPIJobClient(context.Background(), sess, powerinstanceid)
-	return c
 }
 
 func (c *Client) Get(id string) (*models.Image, error) {

--- a/pkg/client/instance/instance.go
+++ b/pkg/client/instance/instance.go
@@ -17,12 +17,13 @@ package instance
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"time"
+
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/ibmpisession"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/ppc64le-cloud/pvsadm/pkg"
-	"regexp"
-	"time"
 )
 
 type Client struct {
@@ -31,11 +32,10 @@ type Client struct {
 }
 
 func NewClient(sess *ibmpisession.IBMPISession, powerinstanceid string) *Client {
-	c := &Client{
+	return &Client{
 		instanceID: powerinstanceid,
+		client:     instance.NewIBMPIInstanceClient(context.Background(), sess, powerinstanceid),
 	}
-	c.client = instance.NewIBMPIInstanceClient(context.Background(), sess, powerinstanceid)
-	return c
 }
 
 func (c *Client) Get(id string) (*models.PVMInstance, error) {

--- a/pkg/client/job/job.go
+++ b/pkg/client/job/job.go
@@ -29,12 +29,11 @@ type Client struct {
 }
 
 func NewClient(sess *ibmpisession.IBMPISession, powerinstanceid string) *Client {
-	c := &Client{
+	return &Client{
 		session:    sess,
 		instanceID: powerinstanceid,
+		client:     instance.NewIBMPIJobClient(context.Background(), sess, powerinstanceid),
 	}
-	c.client = instance.NewIBMPIJobClient(context.Background(), sess, powerinstanceid)
-	return c
 }
 
 func (c *Client) Get(id string) (*models.Job, error) {

--- a/pkg/client/key/key.go
+++ b/pkg/client/key/key.go
@@ -34,12 +34,11 @@ type Client struct {
 }
 
 func NewClient(sess *ibmpisession.IBMPISession, powerinstanceid string) *Client {
-	c := &Client{
+	return &Client{
 		session:    sess,
 		instanceID: powerinstanceid,
+		client:     instance.NewIBMPIKeyClient(context.Background(), sess, powerinstanceid),
 	}
-	c.client = instance.NewIBMPIKeyClient(context.Background(), sess, powerinstanceid)
-	return c
 }
 
 func (c *Client) Get(id string) (*models.SSHKey, error) {

--- a/pkg/client/network/network.go
+++ b/pkg/client/network/network.go
@@ -36,12 +36,11 @@ type Client struct {
 }
 
 func NewClient(sess *ibmpisession.IBMPISession, powerinstanceid string) *Client {
-	c := &Client{
+	return &Client{
 		session:    sess,
 		instanceID: powerinstanceid,
+		client:     instance.NewIBMPINetworkClient(context.Background(), sess, powerinstanceid),
 	}
-	c.client = instance.NewIBMPINetworkClient(context.Background(), sess, powerinstanceid)
-	return c
 }
 
 func (c *Client) Get(id string) (*models.Network, error) {

--- a/pkg/client/volume/volume.go
+++ b/pkg/client/volume/volume.go
@@ -38,12 +38,11 @@ type Client struct {
 }
 
 func NewClient(sess *ibmpisession.IBMPISession, powerinstanceid string) *Client {
-	c := &Client{
+	return &Client{
 		session:    sess,
 		instanceID: powerinstanceid,
+		client:     instance.NewIBMPIVolumeClient(context.Background(), sess, powerinstanceid),
 	}
-	c.client = instance.NewIBMPIVolumeClient(context.Background(), sess, powerinstanceid)
-	return c
 }
 
 func (c *Client) Get(id string) (*models.Volume, error) {

--- a/pkg/utils/sync_test_utils.go
+++ b/pkg/utils/sync_test_utils.go
@@ -42,7 +42,7 @@ func GenerateRandomString(length int) string {
 }
 
 // Generate Specifications
-func GenerateSpec(NoOfTargetsPerSource int) pkg.Spec {
+func GenerateSpec(numTargetsPerSource int) pkg.Spec {
 	var spec pkg.Spec
 	spec.Source = pkg.Source{
 		Bucket:       "image-sync-" + GenerateRandomString(6),
@@ -53,7 +53,7 @@ func GenerateSpec(NoOfTargetsPerSource int) pkg.Spec {
 	}
 
 	spec.Target = make([]pkg.TargetItem, 0)
-	for tgt := 0; tgt < NoOfTargetsPerSource; tgt++ {
+	for tgt := 0; tgt < numTargetsPerSource; tgt++ {
 		spec.Target = append(spec.Target, pkg.TargetItem{
 			Bucket:       "image-sync-" + GenerateRandomString(6),
 			StorageClass: planSlice[randomInt(0, len(planSlice))],

--- a/samples/image-create-and-upload-sample/README.md
+++ b/samples/image-create-and-upload-sample/README.md
@@ -1,5 +1,5 @@
 #### Overview
-The `image_create_and_upload_script` helps to create ova image from qcow2 image, upload the images to a bucket (new/existing) and import them as boot image to pvs workspace using the pvsadm tool
+The `image_create_and_upload_script` helps to create ova image from qcow2 image, upload the images to a bucket (new/existing) and import them as boot image to PowerVS workspace using the pvsadm tool
 #### Prerequisite
 1. Access to shell on IBM Power® logical partition (LPAR) running RHEL 8.x or CentOS 8.x with internet connectivity and minimum 250GB of free disk space
 2. Need a valid RedHat subscription for the RHEL image conversion

--- a/samples/image-create-and-upload-sample/image_create_and_upload_script.sh
+++ b/samples/image-create-and-upload-sample/image_create_and_upload_script.sh
@@ -49,7 +49,7 @@ function standardize_object_name() {
 }
 
 #-------------------------------------------------------------------------
-# Creates the ova image and import into pvs instance
+# Creates the ova image and import into PowerVS workspace
 #-------------------------------------------------------------------------
 function create_and_upload_image() {
   local url=$1

--- a/test/e2e/qcow2ova/qcow2ova.go
+++ b/test/e2e/qcow2ova/qcow2ova.go
@@ -36,6 +36,7 @@ var _ = CMDDescribe("pvsadm qcow2ova tests", func() {
 
 	BeforeSuite(func() {
 		var err error
+		Expect(os.Getenv("IBMCLOUD_API_KEY")).NotTo(BeEmpty(), "IBMCLOUD_API_KEY must be set before running \"make test\"")
 		image, err = os.CreateTemp("", "qcow2ova")
 		Expect(err).NotTo(HaveOccurred())
 		_, err = image.WriteString("some dummy image")
@@ -50,8 +51,8 @@ var _ = CMDDescribe("pvsadm qcow2ova tests", func() {
 		status, stdout, stderr := runImageQcow2OvaCMD(
 			"--help",
 		)
-		Expect(status).To(Equal(0))
-		Expect(stderr).To(Equal(""))
+		Expect(status).To(BeZero())
+		Expect(stderr).To(BeEmpty())
 		Expect(stdout).To(ContainSubstring("Examples:"))
 	})
 
@@ -59,7 +60,7 @@ var _ = CMDDescribe("pvsadm qcow2ova tests", func() {
 		status, _, stderr := runImageQcow2OvaCMD(
 			"--image-url", image.Name(),
 		)
-		Expect(status).NotTo(Equal(0))
+		Expect(status).NotTo(BeZero())
 		Expect(stderr).To(ContainSubstring("image-dist is a mandatory flag"))
 	})
 })

--- a/test/e2e/rootcmd/environment.go
+++ b/test/e2e/rootcmd/environment.go
@@ -33,7 +33,7 @@ var _ = CMDDescribe("run pvsadm with", func() {
 			"-n", "fake_powervs_instance",
 			"--env", "fake",
 		)
-		Expect(status).NotTo(Equal(0))
+		Expect(status).NotTo(BeZero())
 		Expect(stderr).To(ContainSubstring("invalid \"fake\" IBM Cloud Environment passed"))
 	})
 })


### PR DESCRIPTION
No major changes apart from cleaning up docs, variable names and refactoring small segments of code.
These changes are picked-off from #612 to hold changes only related to deprecation of the bluemix-go package.