### PR TITLE
Refer go version from go.mod for workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,10 +52,11 @@ jobs:
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
-    - name: Setup Golang
+    - name: Setup Go
       uses: actions/setup-go@v5
       with:
         go-version-file: 'go.mod'
+    - run: go version
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,9 +8,6 @@ on:
   pull_request:
     branches: [ main ]
 
-env:
-  GO_VERSION: "1.21"
-
 jobs:
 
   build:
@@ -18,17 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go ${{ env.GO_VERSION }}
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ env.GO_VERSION }}
-        check-latest: true
-    - run: go version
-
-    - name: Check out code into the Go module directory
+    - name: Checkout repository
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+
+    - name: Setup Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+    - run: go version
 
     - name: Get dependencies
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,6 @@ on:
     tags:
       - 'v*'
 
-env:
-  GO_VERSION: "1.21"
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -16,14 +13,14 @@ jobs:
       id: get_version
       run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
 
-    - name: Set up Go ${{ env.GO_VERSION }}
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Setup Go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ env.GO_VERSION }}
-        check-latest: true
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+        go-version-file: 'go.mod'
+    - run: go version
 
     - name: Build
       run: |

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/ppc64le-cloud/pvsadm
 
-go 1.21
-toolchain go1.22.4
+go 1.22.4
 
 require (
 	github.com/IBM-Cloud/bluemix-go v0.0.0-20220221162715-e08ea9e7c175


### PR DESCRIPTION
Fixes: #632.
Changes:
Uses go version from go.mod file
