### PR TITLE
Add support for tier0 and tier5k to create boot images

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.4
 
 require (
 	github.com/IBM-Cloud/bluemix-go v0.0.0-20220221162715-e08ea9e7c175
-	github.com/IBM-Cloud/power-go-client v1.7.0
+	github.com/IBM-Cloud/power-go-client v1.7.1
 	github.com/IBM/go-sdk-core/v5 v5.17.4
 	github.com/IBM/ibm-cos-sdk-go v1.11.0
 	github.com/IBM/platform-services-go-sdk v0.66.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/IBM-Cloud/bluemix-go v0.0.0-20220221162715-e08ea9e7c175 h1:FuzMrve2T3v3O2lcI1WA71XJekrW2sX+IC35/X1gYuE=
 github.com/IBM-Cloud/bluemix-go v0.0.0-20220221162715-e08ea9e7c175/go.mod h1:r4ZaLtgP9ghpBmnZd77tSjM2LwfOiCLOG6XmCoutnOQ=
-github.com/IBM-Cloud/power-go-client v1.7.0 h1:/GuGwPMTKoCZACfnwt7b6wKr4v32q1VO1AMFGNETRN4=
-github.com/IBM-Cloud/power-go-client v1.7.0/go.mod h1:9izycYAmNQ+NAdVPXDC3fHYxqWLjlR2YiwqKYveMv5Y=
+github.com/IBM-Cloud/power-go-client v1.7.1 h1:LDEqMGH3KoxgoYfWWM/hG+2fBzy05KFCWygis2fcT3M=
+github.com/IBM-Cloud/power-go-client v1.7.1/go.mod h1:bJZ0gP3MHPNewMFVDXW73/8lJFxXOf8MQR8JaeTyrYo=
 github.com/IBM/go-sdk-core/v5 v5.17.4 h1:VGb9+mRrnS2HpHZFM5hy4J6ppIWnwNrw0G+tLSgcJLc=
 github.com/IBM/go-sdk-core/v5 v5.17.4/go.mod h1:KsAAI7eStAWwQa4F96MLy+whYSh39JzNjklZRbN/8ns=
 github.com/IBM/ibm-cos-sdk-go v1.11.0 h1:Jp55NLN3OvBwucMGpP5wNybyjncsmTZ9+GPHai/1cE8=

--- a/pkg/client/pvmclient.go
+++ b/pkg/client/pvmclient.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ppc64le-cloud/pvsadm/pkg/client/job"
 	"github.com/ppc64le-cloud/pvsadm/pkg/client/key"
 	"github.com/ppc64le-cloud/pvsadm/pkg/client/network"
+	"github.com/ppc64le-cloud/pvsadm/pkg/client/storagetier"
 	"github.com/ppc64le-cloud/pvsadm/pkg/client/volume"
 )
 
@@ -53,6 +54,7 @@ type PVMClient struct {
 	JobClient             *job.Client
 	KeyClient             *key.Client
 	NetworkClient         *network.Client
+	StorageTierClient     *storagetier.Client
 	VolumeClient          *volume.Client
 }
 
@@ -109,6 +111,7 @@ func NewPVMClient(c *Client, instanceID, instanceName, ep string) (*PVMClient, e
 	pvmclient.JobClient = job.NewClient(pvmclient.PISession, instanceID)
 	pvmclient.KeyClient = key.NewClient(pvmclient.PISession, instanceID)
 	pvmclient.NetworkClient = network.NewClient(pvmclient.PISession, instanceID)
+	pvmclient.StorageTierClient = storagetier.NewClient(pvmclient.PISession, pvmclient.InstanceID)
 	pvmclient.VolumeClient = volume.NewClient(pvmclient.PISession, instanceID)
 	return pvmclient, nil
 }

--- a/pkg/client/storagetier/storagetier.go
+++ b/pkg/client/storagetier/storagetier.go
@@ -1,0 +1,37 @@
+// Copyright 2024 IBM Corp
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storagetier
+
+import (
+	"context"
+
+	"github.com/IBM-Cloud/power-go-client/clients/instance"
+	"github.com/IBM-Cloud/power-go-client/ibmpisession"
+	"github.com/IBM-Cloud/power-go-client/power/models"
+)
+
+type Client struct {
+	client *instance.IBMPIStorageTierClient
+}
+
+func NewClient(sess *ibmpisession.IBMPISession, powerinstanceid string) *Client {
+	return &Client{
+		client: instance.NewIBMPIStorageTierClient(context.Background(), sess, powerinstanceid),
+	}
+}
+
+func (c *Client) GetAll() (models.RegionStorageTiers, error) {
+	return c.client.GetAll()
+}


### PR DESCRIPTION
Changes: 
* Tier0 and Tier5k are available in select regions and instances. This change enables users to pick from two additional choices - Tier0 and Tier5k, along with the existing Tier1 and Tier3 storage tiers to create boot images. 
* Validation of tier availability in a given region, using the cloud instance ID.

Tier0 
<img width="1147" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/f945a446-791f-4289-9bee-d8daffc46bc6">

Tier5k
<img width="1153" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/12438559-44e4-42ae-b78f-165221b61f9f">

Invalid storage tier.
```
./pvsadm image import --workspace-id <> --object <> --pvs-image-name <>--pvs-storagetype tier54 --bucket-region jp-tok --watch -v4 -b <>

E0821 11:24:15.770645   58796 main.go:26] provide valid StorageType. Allowable values are [tier3 tier1 tier0 tier5k]
```
