### PR TITLE
Fix CLI operations that involve workspace-name

### DIFF
--- a/pkg/client/pvmclient.go
+++ b/pkg/client/pvmclient.go
@@ -95,16 +95,16 @@ func NewPVMClient(c *Client, instanceID, instanceName string, ep map[string]stri
 		return nil, err
 	}
 
-	pvmclient.DatacenterClient = datacenter.NewClient(pvmclient.PISession, instanceID)
-	pvmclient.DHCPClient = dhcp.NewClient(pvmclient.PISession, instanceID)
-	pvmclient.EventsClient = events.NewClient(pvmclient.PISession, instanceID)
-	pvmclient.ImgClient = image.NewClient(pvmclient.PISession, instanceID)
-	pvmclient.InstanceClient = instance.NewClient(pvmclient.PISession, instanceID)
-	pvmclient.JobClient = job.NewClient(pvmclient.PISession, instanceID)
-	pvmclient.KeyClient = key.NewClient(pvmclient.PISession, instanceID)
-	pvmclient.NetworkClient = network.NewClient(pvmclient.PISession, instanceID)
+	pvmclient.DatacenterClient = datacenter.NewClient(pvmclient.PISession, pvmclient.InstanceID)
+	pvmclient.DHCPClient = dhcp.NewClient(pvmclient.PISession, pvmclient.InstanceID)
+	pvmclient.EventsClient = events.NewClient(pvmclient.PISession, pvmclient.InstanceID)
+	pvmclient.ImgClient = image.NewClient(pvmclient.PISession, pvmclient.InstanceID)
+	pvmclient.InstanceClient = instance.NewClient(pvmclient.PISession, pvmclient.InstanceID)
+	pvmclient.JobClient = job.NewClient(pvmclient.PISession, pvmclient.InstanceID)
+	pvmclient.KeyClient = key.NewClient(pvmclient.PISession, pvmclient.InstanceID)
+	pvmclient.NetworkClient = network.NewClient(pvmclient.PISession, pvmclient.InstanceID)
 	pvmclient.StorageTierClient = storagetier.NewClient(pvmclient.PISession, pvmclient.InstanceID)
-	pvmclient.VolumeClient = volume.NewClient(pvmclient.PISession, instanceID)
+	pvmclient.VolumeClient = volume.NewClient(pvmclient.PISession, pvmclient.InstanceID)
 	return pvmclient, nil
 }
 


### PR DESCRIPTION
Fixes: #655

* Changes picked off #659 

```
./pvsadm purge images --workspace-name X
I0911 18:03:31.512405   65442 images.go:37] Purge the images for the workspace:
+--------------------------+-------------+--------------------------------------+--------------------------+-----------------+--------+-------------+-------------+
|       CREATIONDATE       | DESCRIPTION |               IMAGEID                |      LASTUPDATEDATE      |      NAME       | STATE  | STORAGEPOOL | STORAGETYPE |
+--------------------------+-------------+--------------------------------------+--------------------------+-----------------+--------+-------------+-------------+
| 2024-09-11T09:02:29.000Z |             | e5780844-86c9-4d4c-9272-6bb2519dXXXX | 2024-09-11T09:02:29.000Z | CentOS-Stream-9 | active |             |             |
| 2024-08-16T07:00:59.000Z |             | f57a0ae7-d283-4267-a32e-02240ddcXXXX | 2024-08-16T07:00:59.000Z | RHEL8-SP8-BYOL  | active |             |             |
+--------------------------+-------------+--------------------------------------+--------------------------+-----------------+--------+-------------+-------------+


./pvsadm purge images --workspace-id 45489157-5e0c-4147-83a7-54a2d96bXXXX
I0911 18:04:01.605522   65668 images.go:37] Purge the images for the workspace: 45489157-5e0c-4147-83a7-54a2d96b0233
+--------------------------+-------------+--------------------------------------+--------------------------+-----------------+--------+-------------+-------------+
|       CREATIONDATE       | DESCRIPTION |               IMAGEID                |      LASTUPDATEDATE      |      NAME       | STATE  | STORAGEPOOL | STORAGETYPE |
+--------------------------+-------------+--------------------------------------+--------------------------+-----------------+--------+-------------+-------------+
| 2024-09-11T09:02:29.000Z |             | e5780844-86c9-4d4c-9272-6bb2519dXXXX | 2024-09-11T09:02:29.000Z | CentOS-Stream-9 | active |             |             |
| 2024-08-16T07:00:59.000Z |             | f57a0ae7-d283-4267-a32e-02240ddcXXXX | 2024-08-16T07:00:59.000Z | RHEL8-SP8-BYOL  | active |             |             |
+--------------------------+-------------+--------------------------------------+--------------------------+-----------------+--------+-------------+-------------+
```