### PR TITLE
Support port creation through workspace name

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -33,4 +33,7 @@ func init() {
 	Cmd.PersistentFlags().StringVarP(&pkg.Options.WorkspaceID, "instance-id", "i", "", "Instance ID of the PowerVS instance")
 	Cmd.PersistentFlags().MarkDeprecated("instance-id", "instance-id is deprecated, workspace-id should be used")
 	Cmd.PersistentFlags().StringVarP(&pkg.Options.WorkspaceID, "workspace-id", "", "", "Workspace ID of the PowerVS workspace")
+	Cmd.PersistentFlags().StringVarP(&pkg.Options.WorkspaceName, "instance-name", "n", "", "Instance name of the PowerVS instance")
+	Cmd.PersistentFlags().MarkDeprecated("instance-name", "instance-name is deprecated, workspace-name should be used")
+	Cmd.PersistentFlags().StringVarP(&pkg.Options.WorkspaceName, "workspace-name", "", "", "Workspace name of the PowerVS workspace")
 }

--- a/cmd/create/port/port.go
+++ b/cmd/create/port/port.go
@@ -36,10 +36,7 @@ var Cmd = &cobra.Command{
 	Short: "Create PowerVS network port",
 	Long:  `Create PowerVS network port`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		if pkg.Options.WorkspaceID == "" {
-			return fmt.Errorf("--workspace-id required")
-		}
-		return nil
+		return utils.EnsureWorkspaceIDorNameIsSet(pkg.Options.WorkspaceID, pkg.Options.WorkspaceName)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		opt := pkg.Options


### PR DESCRIPTION
Add support to create port by `--workspace-name`. Added flags to parse `--workspace-name` for ease of usage.
```
./pvsadm create port --workspace-name XXX-test-csi-k8s --network c922fe46-4b71-XXXX-XXXX-168e0794419e
Error: unknown flag: --workspace-name
```
Tests:

Using workspace name
```
./pvsadm create port --workspace-name XXX-test-csi-k8s --network c922fe46-4b71-XXXX-XXXX-168e0794419e
W0912 14:41:26.223930   55924 root.go:54] IBMCLOUD_API_KEY will be deprecated in future releases. Use IBMCLOUD_APIKEY instead.
I0912 14:41:32.615848   55924 port.go:89] Successfully created a port, id: a4f7a177-eb14-4552-9123-fb61bf7XXXX I0912 14:41:32.615848   55924 port.go:89] Successfully created a port, id: a4f7a177-eb14-4552-9123-fb61bf70XXXX
+-------------+------------+------+---------------+-------------------+--------------------------------------+-------------+--------+
| DESCRIPTION | EXTERNALIP | HREF |   IPADDRESS   |    MACADDRESS     |                PORTID                | PVMINSTANCE | STATUS |
+-------------+------------+------+---------------+-------------------+--------------------------------------+-------------+--------+
|             |            |      | 192.168.232.3 | fa:16:3e:d4:25:ae | a4f7a177-eb14-4552-9123-fb61bf70XXXX |             | DOWN   |
+-------------+------------+------+---------------+-------------------+--------------------------------------+-------------+--------+
```
Using workspace ID
```
./pvsadm create port --workspace-id 45489157-XXXX-XXXX-XXXX-54a2d96b0233 --network c922fe46-XXXX-XXXX-8c1c-168e0794419e
W0912 14:45:46.354622   57573 root.go:54] IBMCLOUD_API_KEY will be deprecated in future releases. Use IBMCLOUD_APIKEY instead.
I0912 14:45:51.514981   57573 port.go:89] Successfully created a port, id: 563472d6-1225-4c9e-b4ce-c45a472cXXXX
+-------------+------------+------+---------------+-------------------+--------------------------------------+-------------+--------+
| DESCRIPTION | EXTERNALIP | HREF |   IPADDRESS   |    MACADDRESS     |                PORTID                | PVMINSTANCE | STATUS |
+-------------+------------+------+---------------+-------------------+--------------------------------------+-------------+--------+
|             |            |      | 192.168.232.4 | fa:16:3e:29:a0:ec | 563472d6-1225-4c9e-b4ce-c45a472XXXX |             | DOWN   |
+-------------+------------+------+---------------+-------------------+--------------------------------------+-------------+--------+
```
Missing workspace id/name
```
./pvsadm create port
W0912 14:48:13.027461   58383 root.go:54] IBMCLOUD_API_KEY will be deprecated in future releases. Use IBMCLOUD_APIKEY instead.
Error: --workspace-id or --workspace-name required
```