### PR TITLE
Fix broken version command.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,7 +23,7 @@ IMP: Please don't mention any credentials or API keys
 **Anything else we need to know?**:
 
 **Environment**:
-- pvsadm version (use `pvsadm version`):
+- pvsadm version (use `pvsadm --version`):
 - Environment - On-Prem or IBM PowerVS:
 - OS (e.g: `cat /etc/os-release`):
 - Kernel (e.g. `uname -a`):

--- a/cmd/create/port/port.go
+++ b/cmd/create/port/port.go
@@ -36,7 +36,7 @@ var Cmd = &cobra.Command{
 	Short: "Create PowerVS network port",
 	Long:  `Create PowerVS network port`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		return utils.EnsureWorkspaceIDorNameIsSet(pkg.Options.WorkspaceID, pkg.Options.WorkspaceName)
+		return utils.EnsurePrerequisitesAreSet(pkg.Options.APIKey, pkg.Options.WorkspaceID, pkg.Options.WorkspaceName)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		opt := pkg.Options

--- a/cmd/get/events/events.go
+++ b/cmd/get/events/events.go
@@ -34,7 +34,7 @@ var Cmd = &cobra.Command{
 	Short: "Get Powervs events",
 	Long:  `Get the PowerVS events`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		return utils.EnsureWorkspaceIDorNameIsSet(pkg.Options.WorkspaceID, pkg.Options.WorkspaceName)
+		return utils.EnsurePrerequisitesAreSet(pkg.Options.APIKey, pkg.Options.WorkspaceID, pkg.Options.WorkspaceName)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		opt := pkg.Options

--- a/cmd/get/peravailability/peravailability.go
+++ b/cmd/get/peravailability/peravailability.go
@@ -32,7 +32,7 @@ var Cmd = &cobra.Command{
 	Short: "List regions that support PER",
 	Long:  "List regions that support Power Edge Router (PER)",
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		return utils.EnsureWorkspaceIDorNameIsSet(pkg.Options.WorkspaceID, pkg.Options.WorkspaceName)
+		return utils.EnsurePrerequisitesAreSet(pkg.Options.APIKey, pkg.Options.WorkspaceID, pkg.Options.WorkspaceName)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var perEnabledRegions []string

--- a/cmd/get/ports/ports.go
+++ b/cmd/get/ports/ports.go
@@ -35,7 +35,7 @@ var Cmd = &cobra.Command{
 	Short: "Get PowerVS network ports",
 	Long:  `Get PowerVS network ports`,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		return utils.EnsureWorkspaceIDorNameIsSet(pkg.Options.WorkspaceID, pkg.Options.WorkspaceName)
+		return utils.EnsurePrerequisitesAreSet(pkg.Options.APIKey, pkg.Options.WorkspaceID, pkg.Options.WorkspaceName)
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		opt := pkg.Options

--- a/cmd/image/import/import.go
+++ b/cmd/image/import/import.go
@@ -140,22 +140,17 @@ pvsadm image import -n upstream-core-lon04 -b <BUCKETNAME> --object rhel-83-1003
 pvsadm image import -n upstream-core-lon04 -b <BUCKETNAME> --object rhel-83-10032020.ova.gz --pvs-image-name test-image -r <REGION> --public-bucket
 `,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		if pkg.ImageCMDOptions.WorkspaceID == "" && pkg.ImageCMDOptions.WorkspaceName == "" {
-			return fmt.Errorf("--workspace-name or --workspace-id required")
-		}
-
 		// ensure that both, the AccessKey and SecretKey are either both set or unset
 		if (len(pkg.ImageCMDOptions.AccessKey) > 0) != (len(pkg.ImageCMDOptions.SecretKey) > 0) {
 			return fmt.Errorf("required both --accesskey and --secretkey values")
 		}
-		return nil
+		return utils.EnsurePrerequisitesAreSet(pkg.Options.APIKey, pkg.ImageCMDOptions.WorkspaceID, pkg.ImageCMDOptions.WorkspaceName)
 	},
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		opt := pkg.ImageCMDOptions
-		apikey := pkg.Options.APIKey
 
-		pvsClient, err := client.NewClientWithEnv(apikey, pkg.Options.Environment, pkg.Options.Debug)
+		pvsClient, err := client.NewClientWithEnv(pkg.Options.APIKey, pkg.Options.Environment, pkg.Options.Debug)
 		if err != nil {
 			return err
 		}

--- a/cmd/purge/purge.go
+++ b/cmd/purge/purge.go
@@ -85,7 +85,8 @@ Examples:
 		if pkg.Options.Since != 0 && pkg.Options.Before != 0 {
 			return fmt.Errorf("--since and --before options can not be set at a time")
 		}
-		return utils.EnsureWorkspaceIDorNameIsSet(pkg.Options.WorkspaceID, pkg.Options.WorkspaceName)
+
+		return utils.EnsurePrerequisitesAreSet(pkg.Options.APIKey, pkg.Options.WorkspaceID, pkg.Options.WorkspaceName)
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ import (
 	goflag "flag"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -31,15 +32,17 @@ import (
 	"github.com/ppc64le-cloud/pvsadm/cmd/get"
 	"github.com/ppc64le-cloud/pvsadm/cmd/image"
 	"github.com/ppc64le-cloud/pvsadm/cmd/purge"
-	"github.com/ppc64le-cloud/pvsadm/cmd/version"
+	versioncmd "github.com/ppc64le-cloud/pvsadm/cmd/version"
 	"github.com/ppc64le-cloud/pvsadm/pkg"
 	"github.com/ppc64le-cloud/pvsadm/pkg/audit"
 	"github.com/ppc64le-cloud/pvsadm/pkg/client"
+	"github.com/ppc64le-cloud/pvsadm/pkg/version"
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "pvsadm",
-	Short: "pvsadm is a command line tool for managing IBM Cloud PowerVS infrastructure",
+	Use:     "pvsadm",
+	Version: version.Version + " " + fmt.Sprintf("GoVersion: %s\n", runtime.Version()),
+	Short:   "pvsadm is a command line tool for managing IBM Cloud PowerVS infrastructure",
 	Long: `Power Systems Virtual Server projects deliver flexible compute capacity for Power Systems workloads.
 Integrated with the IBM Cloud platform for on-demand provisioning.
 
@@ -65,11 +68,6 @@ This is a tool built for the Power Systems Virtual Server helps managing and mai
 			os.Setenv("IBMCLOUD_APIKEY", pkg.Options.APIKey)
 		}
 
-		// If the API-key is still unset, it's highly likely that the API key was neither set through the environment variable nor the flag.
-		if pkg.Options.APIKey == "" {
-			return fmt.Errorf("api-key can't be empty, pass the token via --api-key or set IBMCLOUD_APIKEY environment variable")
-		}
-
 		if _, err := client.GetEnvironment(pkg.Options.Environment); err != nil {
 			return fmt.Errorf("invalid \"%s\" IBM Cloud Environment passed, valid values are: %s", pkg.Options.Environment, strings.Join(client.ListEnvironments(), ", "))
 		}
@@ -82,6 +80,7 @@ func init() {
 	klog.InitFlags(nil)
 	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 
+	rootCmd.SetVersionTemplate(`Version: {{.Version}}`)
 	rootCmd.AddGroup(&cobra.Group{ID: "resource", Title: "Resource Management Commands:"})
 	rootCmd.AddGroup(&cobra.Group{ID: "dhcp", Title: "DHCP Commands:"})
 	rootCmd.AddGroup(&cobra.Group{ID: "image", Title: "Image Commands:"})
@@ -90,7 +89,8 @@ func init() {
 	rootCmd.SetCompletionCommandGroupID("admin")
 	rootCmd.AddCommand(purge.Cmd)
 	rootCmd.AddCommand(get.Cmd)
-	rootCmd.AddCommand(version.Cmd)
+	// TODO : Remove the version command in a future release.
+	rootCmd.AddCommand(versioncmd.Cmd)
 	rootCmd.AddCommand(image.Cmd)
 	rootCmd.AddCommand(create.Cmd)
 	rootCmd.AddCommand(deletecmd.Cmd)

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -24,9 +24,10 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:     "version",
-	Short:   "Print the version number",
-	GroupID: "admin",
+	Use:        "version",
+	Short:      "Print the version number",
+	Deprecated: "Please use pvsadm --version instead.",
+	GroupID:    "admin",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Printf("Version: %s, GoVersion: %s\n", version.Get(), runtime.Version())
 	},

--- a/get.sh
+++ b/get.sh
@@ -75,6 +75,7 @@ function install_pvsadm() {
 
     if command -v "pvsadm" &> /dev/null; then
         echo "pvsadm is already installed!"
+        # TODO: move to pvsadm --version for future releases.
         pvsadm version
         exit 1
     fi
@@ -91,7 +92,7 @@ function install_pvsadm() {
     fi
 
     chmod +x /usr/local/bin/pvsadm
-    pvsadm version
+    pvsadm --version
 }
 
 function run (){

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -37,7 +37,12 @@ func Contains(s []string, e string) bool {
 	return false
 }
 
-func EnsureWorkspaceIDorNameIsSet(workspaceID, workspaceName string) error {
+// Ensure that either the workspaceID or the workspaceName is set, along with the API Key.
+func EnsurePrerequisitesAreSet(apiKey, workspaceID, workspaceName string) error {
+	if apiKey == "" {
+		return fmt.Errorf("api-key can't be empty, pass the token via --api-key or set IBMCLOUD_APIKEY environment variable")
+	}
+
 	if workspaceID == "" && workspaceName == "" {
 		return fmt.Errorf("--workspace-id or --workspace-name required")
 	}


### PR DESCRIPTION
Fixes: #664 

Changes: 
The API-Key check has been added to other pre-requisites that need to be set for command execution.
An option to set the version through the existing cobra framework is used.
This will reduce the additional subcommand that is designed to return the tool version, while having it deprecated.