### PR TITLE
Fix get.sh to select between --version and version subcommand

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -67,6 +67,16 @@ function check_connectivity() {
 
 function install_pvsadm() {
 
+    local major=0
+    local minor=0
+    local patch=0
+
+    if [[ "$VERSION" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+        major=${BASH_REMATCH[1]}
+        minor=${BASH_REMATCH[2]}
+        patch=${BASH_REMATCH[3]}
+    fi
+
     if [[ "${FORCE}" -eq 1 ]]; then
        if command -v "pvsadm" &> /dev/null; then
            rm -f /usr/local/bin/pvsadm
@@ -75,8 +85,7 @@ function install_pvsadm() {
 
     if command -v "pvsadm" &> /dev/null; then
         echo "pvsadm is already installed!"
-        # TODO: move to pvsadm --version for future releases.
-        pvsadm version
+        print_version $major $minor $patch
         exit 1
     fi
 
@@ -92,7 +101,21 @@ function install_pvsadm() {
     fi
 
     chmod +x /usr/local/bin/pvsadm
-    pvsadm --version
+    print_version $major $minor $patch
+}
+
+function print_version() {
+    # check if version is < 0.1.17, which uses the pvsadm subcommand
+    local major=$1
+    local minor=$2
+    local patch=$3
+    if [ $major -lt 1 ] && [ $minor -lt 2 ] && [ $patch -lt 17 ];
+    then
+        pvsadm version
+    # the more recent releases support the version flag
+    else
+        pvsadm --version
+    fi
 }
 
 function run (){


### PR DESCRIPTION
Binary already exists in path : 

```  
VERSION=v0.1.15 ./get.sh

To replace an old version of pvsadm, run this script with an environment variable: FORCE=1

pvsadm is already installed!
Version: v0.1.15, GoVersion: go1.21.11
-----------
VERSION=v0.1.18 ./get.sh. <- manually built from source with the version tag set to 1.18

To replace an old version of pvsadm, run this script with an environment variable: FORCE=1

pvsadm is already installed!
Version: 0.18.0 GoVersion: go1.22.4
```

A binary is required to be installed
```
VERSION=v0.1.15 ./get.sh

To replace an old version of pvsadm, run this script with an environment variable: FORCE=1

############################################################################################################# 100.0%
Version: v0.1.15, GoVersion: go1.21.11
```

Additional notes: 
0.1.16 does also seem to report of the API key required to be set :  #664. 