### PR TITLE
Limit --since and --after options to keys and VMs

### DIFF
--- a/cmd/purge/keys/keys.go
+++ b/cmd/purge/keys/keys.go
@@ -16,6 +16,7 @@ package keys
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 	"k8s.io/klog/v2"
@@ -82,4 +83,10 @@ pvsadm purge --help for information
 		}
 		return nil
 	},
+}
+
+func init() {
+	Cmd.PersistentFlags().DurationVar(&pkg.Options.Since, "since", 0*time.Second, "Remove resources since mentioned duration(format: 99h99m00s), mutually exclusive with --before")
+	Cmd.PersistentFlags().DurationVar(&pkg.Options.Before, "before", 0*time.Second, "Remove resources before mentioned duration(format: 99h99m00s), mutually exclusive with --since")
+	Cmd.MarkFlagsMutuallyExclusive("since", "before")
 }

--- a/cmd/purge/purge.go
+++ b/cmd/purge/purge.go
@@ -15,8 +15,7 @@
 package purge
 
 import (
-	"fmt"
-	"time"
+	"github.com/spf13/cobra"
 
 	"github.com/ppc64le-cloud/pvsadm/cmd/purge/images"
 	"github.com/ppc64le-cloud/pvsadm/cmd/purge/keys"
@@ -25,7 +24,6 @@ import (
 	"github.com/ppc64le-cloud/pvsadm/cmd/purge/volumes"
 	"github.com/ppc64le-cloud/pvsadm/pkg"
 	"github.com/ppc64le-cloud/pvsadm/pkg/utils"
-	"github.com/spf13/cobra"
 )
 
 var Cmd = &cobra.Command{
@@ -81,11 +79,6 @@ Examples:
 		if err := root.PersistentPreRunE(cmd, args); err != nil {
 			return err
 		}
-
-		if pkg.Options.Since != 0 && pkg.Options.Before != 0 {
-			return fmt.Errorf("--since and --before options can not be set at a time")
-		}
-
 		return utils.EnsurePrerequisitesAreSet(pkg.Options.APIKey, pkg.Options.WorkspaceID, pkg.Options.WorkspaceName)
 	},
 }
@@ -103,8 +96,6 @@ func init() {
 	Cmd.PersistentFlags().StringVarP(&pkg.Options.WorkspaceID, "workspace-id", "", "", "Workspace ID of the PowerVS workspace")
 	Cmd.PersistentFlags().StringVarP(&pkg.Options.WorkspaceName, "workspace-name", "", "", "Workspace name of the PowerVS workspace")
 	Cmd.PersistentFlags().BoolVar(&pkg.Options.DryRun, "dry-run", false, "dry run the action and don't delete the actual resources")
-	Cmd.PersistentFlags().DurationVar(&pkg.Options.Since, "since", 0*time.Second, "Remove resources since mentioned duration(format: 99h99m00s), mutually exclusive with --before")
-	Cmd.PersistentFlags().DurationVar(&pkg.Options.Before, "before", 0*time.Second, "Remove resources before mentioned duration(format: 99h99m00s), mutually exclusive with --since")
 	Cmd.PersistentFlags().BoolVar(&pkg.Options.NoPrompt, "no-prompt", false, "Show prompt before doing any destructive operations")
 	Cmd.PersistentFlags().BoolVar(&pkg.Options.IgnoreErrors, "ignore-errors", false, "Ignore any errors during the operations")
 	Cmd.PersistentFlags().StringVar(&pkg.Options.Expr, "regexp", "", "Regular Expressions for filtering the selection")

--- a/cmd/purge/vms/vms.go
+++ b/cmd/purge/vms/vms.go
@@ -17,13 +17,15 @@ package vms
 import (
 	"fmt"
 	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
 
 	"github.com/ppc64le-cloud/pvsadm/pkg"
 	"github.com/ppc64le-cloud/pvsadm/pkg/audit"
 	"github.com/ppc64le-cloud/pvsadm/pkg/client"
 	"github.com/ppc64le-cloud/pvsadm/pkg/utils"
-	"github.com/spf13/cobra"
-	"k8s.io/klog/v2"
 )
 
 var Cmd = &cobra.Command{
@@ -89,4 +91,10 @@ pvsadm purge --help for information
 		}
 		return nil
 	},
+}
+
+func init() {
+	Cmd.PersistentFlags().DurationVar(&pkg.Options.Since, "since", 0*time.Second, "Remove resources since mentioned duration(format: 99h99m00s), mutually exclusive with --before")
+	Cmd.PersistentFlags().DurationVar(&pkg.Options.Before, "before", 0*time.Second, "Remove resources before mentioned duration(format: 99h99m00s), mutually exclusive with --since")
+	Cmd.MarkFlagsMutuallyExclusive("since", "before")
 }


### PR DESCRIPTION
**Background:**
The `--since` and `--before` flags were included at the purge command level, while certain child commands do not support the same. 
Changes are made to limit the options to the child commands to have a more concise set of options for the respective commands.


For networks:
```
Using the options that do not exist anymore
Kishens-MacBook-Pro-2➜  bin : port-deletion : ᐅ  ./pvsadm purge networks --workspace-id <> --ignore-errors --no-prompt --ports --instances --since 1h --before 1h
 E1015 08:40:24.671575   80887 main.go:26] unknown flag: --since
 
 
Without --before and --since flags
Kishens-MacBook-Pro-2➜  bin : port-deletion ✘ :✭ ᐅ  ./pvsadm purge networks --workspace-id <> --ports --instances
I1015 10:04:19.482878   97874 networks.go:54] Purge networks for the workspace ID: <>
+--------------+-----+-------------+-------+------+-------------------------------------+--------------------------------------+----------+--------+
| ACCESSCONFIG | CRN | DHCPMANAGED | JUMBO | MTU  |                NAME                 |              NETWORKID               |   TYPE   | VLANID |
+--------------+-----+-------------+-------+------+-------------------------------------+--------------------------------------+----------+--------+
|              |     | false       | true  | 9000 | public-192_168_234_176-29-VLAN_2150 | <>| pub-vlan |   2150 |
+--------------+-----+-------------+-------+------+-------------------------------------+--------------------------------------+----------+--------+
┃ Deleting all the above networks and the action is irreversible. Do you really want to continue?
┃
┃                                           Yes     No

 
```

For VMs:
```
Setting both flags that are meant to be mutually exclusive:

Kishens-MacBook-Pro-2➜  bin : port-deletion ✘ :✹✭ ᐅ  ./pvsadm purge vms --workspace-id <> --since 1h --before 1h
Error: if any flags in the group [since before] are set none of the others can be; [before since] were all set
 E1015 09:24:17.813825   82821 main.go:26] if any flags in the group [since before] are set none of the others can be; [before since] were all set
 
Using --before flag
Kishens-MacBook-Pro-2➜  bin : port-deletion ✘ : ᐅ  ./pvsadm purge vms --workspace-id <> --before 1h
+-----------------------------+--------------+--------------------------------------+------+-----+-----------------+--------------------------+
|            NAME             | IP ADDRESSES |                IMAGE                 | CPUS | RAM |     STATUS      |      CREATION DATE       |
+-----------------------------+--------------+--------------------------------------+------+-----+-----------------+--------------------------+
| <>  | External:    | <> |  0.5 |  32 | Status: ACTIVE  | 2024-10-14T09:11:36.000Z |
|                             | Private:     |                                      |      |     | Health: WARNING |                          |
| <>  | External:    | <> |  0.5 |  32 | Status: ACTIVE  | 2024-10-14T09:11:21.000Z |
|                             | Private:     |                                      |      |     | Health: WARNING |                          |
+-----------------------------+--------------+--------------------------------------+------+-----+-----------------+--------------------------+
┃ Deleting all the above instances and the action is irreversible. Do you really want to continue?
┃
┃                                            Yes     No

Using --since flag:

Kishens-MacBook-Pro-2➜  bin : port-deletion ✘ :✭ ᐅ  ./pvsadm purge vms --workspace-id <> --since 1h
+------------+--------------------------+--------------------------------------+------+-----+----------------+--------------------------+
|    NAME    |       IP ADDRESSES       |                IMAGE                 | CPUS | RAM |     STATUS     |      CREATION DATE       |
+------------+--------------------------+--------------------------------------+------+-----+----------------+--------------------------+
| <> | External: 52.118.31.214  | <> | 0.25 |   4 | Status: ACTIVE | 2024-10-15T04:06:38.000Z |
|            | Private: 192.168.234.182 |                                      |      |     | Health: OK     |                          |
+------------+--------------------------+--------------------------------------+------+-----+----------------+--------------------------+
┃ Deleting all the above instances and the action is irreversible. Do you really want to continue?
┃
┃                                            Yes     No


```


For Keys: 
```
Using the --before flag:
Kishens-MacBook-Pro-2➜  bin : port-deletion  ᐅ  ./pvsadm purge keys --workspace-id <> --regexp kishen --before 1h
I1015 09:34:09.154279   86241 keys.go:49] Purge SSH keys for the workspace ID: <>
I1015 09:34:16.285375   86241 keys.go:68] keys matched are [kishen-mbp-rsa]
┃ Deleting all the above keys and the action is irreversible. Do you really want to continue?
┃
┃                                         Yes     No

Using the --since flag:
Kishens-MacBook-Pro-2➜  bin : port-deletion ✘ :✭ ᐅ  ./pvsadm purge keys --workspace-id <> --regexp kishen --since 100000h
I1015 10:00:35.210025   96640 keys.go:49] Purge SSH keys for the workspace ID: <>
I1015 10:00:42.552181   96640 keys.go:68] keys matched are [kishen-mbp-rsa]
┃ Deleting all the above keys and the action is irreversible. Do you really want to continue?
┃
┃                                         Yes     No

Using --before and --since flag
Kishens-MacBook-Pro-2➜  bin : port-deletion ✘ :✭ ᐅ  ./pvsadm purge keys --workspace-id <> --regexp kishen --since 100000h --before 1h
Error: if any flags in the group [since before] are set none of the others can be; [before since] were all set
```