### PR TITLE
Introduces Github workflow to update homebrew formula in pvsadm tap repository on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,17 +156,3 @@ jobs:
         asset_path: pvsadm-binaries.tar.gz
         asset_name: pvsadm-binaries.tar.gz
         asset_content_type: application/tar+gzip
-
-    - name: Update Homebrew formula
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN}}
-      run: |
-        git config --global user.name "pvsadm GitHub Actions"
-        git config --global user.email "pvsadmactions@github.com"
-        GET_VERSION_OUTPUT="${{ steps.get_version.outputs.VERSION }}"
-        NEW_VERSION=${GET_VERSION_OUTPUT#v}
-        BASE_REPO_URL="https://github.com/${GITHUB_REPOSITORY}"
-        BREW_TAP_REPO_URL="https://github.com/ppc64le-cloud/homebrew-pvsadm"
-        FORMULA_FILE="pvsadm.rb"
-        ./ci/brew_formula_updater.sh "$BASE_REPO_URL" "$NEW_VERSION" "$BREW_TAP_REPO_URL" "$FORMULA_FILE"

--- a/.github/workflows/update-homebrew-formula.yml
+++ b/.github/workflows/update-homebrew-formula.yml
@@ -1,0 +1,41 @@
+name: Update Homebrew Formula on Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-homebrew:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Get GitHub App User ID and setup the git environment
+      id: get-user-id
+      run: echo "user-id=$(gh api "/users/${{ steps.app-token.outputs.app-slug }}[bot]" --jq .id)" >> "$GITHUB_OUTPUT"
+      env:
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+    - run: |
+        git config --global user.name '${{ steps.app-token.outputs.app-slug }}[bot]'
+        git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com>'
+
+    - name: Generate GitHub App Token
+      uses: actions/create-github-app-token@v1
+      id: app-token
+      with:
+        app-id: ${{ vars.APP_ID }}
+        private-key: ${{ secrets.PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+
+    - name: Update Homebrew formula
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN}}
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
+      run: |
+        RELEASE_VERSION=${{ github.event.release.tag_name#v }}
+        BASE_REPO_URL="https://github.com/${GITHUB_REPOSITORY}"
+        BREW_TAP_REPO_URL="https://github.com/ppc64le-cloud/homebrew-pvsadm"
+        FORMULA_FILE="pvsadm.rb"
+        ./ci/brew_formula_updater.sh "$BASE_REPO_URL" "$RELEASE_VERSION" "$BREW_TAP_REPO_URL" "$FORMULA_FILE"


### PR DESCRIPTION
Introduces Github workflow specifically to update homebrew formula in pvsadm tap repository

Notes - 
1. Configured to run only on release publish event
2. Requires a GitHub App installed in this repo and tap repo (https://github.com/ppc64le-cloud/homebrew-pvsadm) with following APP permissions - `Actions, Pull requests`

