### PR TITLE
Updated proper response for no records while executing purge command

### DIFF
--- a/cmd/purge/vms/vms.go
+++ b/cmd/purge/vms/vms.go
@@ -52,6 +52,11 @@ pvsadm purge --help for information
 			return err
 		}
 
+		if len(instances) == 0 {
+			klog.Info("\n--NO DATA FOUND--")
+			return nil
+		}
+
 		t := utils.NewTable()
 		t.SetHeader([]string{"Name", "IP Addresses", "Image", "CPUS", "RAM", "STATUS", "Creation Date"})
 		for _, instance := range instances {

--- a/cmd/purge/vms/vms.go
+++ b/cmd/purge/vms/vms.go
@@ -53,7 +53,7 @@ pvsadm purge --help for information
 		}
 
 		if len(instances) == 0 {
-			klog.Info("\n--NO DATA FOUND--")
+			klog.Info("No data found to display")
 			return nil
 		}
 

--- a/cmd/purge/volumes/volumes.go
+++ b/cmd/purge/volumes/volumes.go
@@ -16,12 +16,14 @@ package volumes
 
 import (
 	"fmt"
+
+	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
+
 	"github.com/ppc64le-cloud/pvsadm/pkg"
 	"github.com/ppc64le-cloud/pvsadm/pkg/audit"
 	"github.com/ppc64le-cloud/pvsadm/pkg/client"
 	"github.com/ppc64le-cloud/pvsadm/pkg/utils"
-	"github.com/spf13/cobra"
-	"k8s.io/klog/v2"
 )
 
 var Cmd = &cobra.Command{
@@ -46,6 +48,11 @@ pvsadm purge --help for information
 		volumes, err := pvmclient.VolumeClient.GetAllPurgeableByLastUpdateDate(opt.Before, opt.Since, opt.Expr)
 		if err != nil {
 			return fmt.Errorf("failed to get the list of volumes: %v", err)
+		}
+
+		if len(volumes) == 0 {
+			klog.Info("\n--NO DATA FOUND--")
+			return nil
 		}
 
 		t := utils.NewTable()

--- a/cmd/purge/volumes/volumes.go
+++ b/cmd/purge/volumes/volumes.go
@@ -51,7 +51,7 @@ pvsadm purge --help for information
 		}
 
 		if len(volumes) == 0 {
-			klog.Info("\n--NO DATA FOUND--")
+			klog.Info("No data found to display")
 			return nil
 		}
 

--- a/pkg/utils/table.go
+++ b/pkg/utils/table.go
@@ -16,13 +16,15 @@ package utils
 
 import (
 	"fmt"
-	"github.com/go-openapi/strfmt"
-	"github.com/olekukonko/tablewriter"
 	"os"
 	"reflect"
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/olekukonko/tablewriter"
+	"k8s.io/klog/v2"
 )
 
 type Table struct {
@@ -49,9 +51,8 @@ func (t *Table) Render(rows interface{}, exclude []string) {
 		s := reflect.ValueOf(rows)
 		for i := 0; i < s.Len(); i++ {
 			noData = false
-			var headers []string
+			var headers, row []string
 			val := s.Index(i).Elem()
-			var row []string
 			for i := 0; i < val.NumField(); i++ {
 				if f := strings.ToLower(val.Type().Field(i).Name); Contains(exclude, f) {
 					continue
@@ -65,7 +66,7 @@ func (t *Table) Render(rows interface{}, exclude []string) {
 		}
 	}
 	if noData {
-		fmt.Println("\n--NO DATA FOUND--")
+		klog.Info("\n--NO DATA FOUND--")
 	}
 	t.Table.Render()
 }

--- a/pkg/utils/table.go
+++ b/pkg/utils/table.go
@@ -66,7 +66,7 @@ func (t *Table) Render(rows interface{}, exclude []string) {
 		}
 	}
 	if noData {
-		klog.Info("\n--NO DATA FOUND--")
+		klog.Info("No data found to display")
 	}
 	t.Table.Render()
 }


### PR DESCRIPTION
This fix is to maintain consistency in response of purge command responses. When we are trying to purge and there is no response, purge networks and purge images are providing no data found response whereas purge vms and purge volumes are providing empty table. As part of this fix we are trying to fix the issue.

**Before**
<img width="1100" alt="image" src="https://github.com/user-attachments/assets/77897a97-1dda-40c9-9272-474429b88d0c">

<img width="1100" alt="image" src="https://github.com/user-attachments/assets/3a61a799-bfa6-4d1a-bd9c-0932d4ab4bef">


**After**
<img width="1100" alt="image" src="https://github.com/user-attachments/assets/82441254-c2f0-4177-a5a1-d1c61cb1ef9a">

<img width="1100" alt="image" src="https://github.com/user-attachments/assets/b2810db2-af17-4a6e-9086-5e7968983d10">
