### PR TITLE
Added fix for handling the file extensions in the boot directory.

### DIFF
--- a/cmd/image/qcow2ova/prep/prepare.go
+++ b/cmd/image/qcow2ova/prep/prepare.go
@@ -105,7 +105,7 @@ func prepare(mnt, volume, dist, rhnuser, rhnpasswd, rootpasswd string) error {
 	}
 
 	// Verify /boot is mounted properly and files are present.
-	bootDirFiles := []string{"config-*.ppc64le", "efi", "grub2", "initramfs-*.ppc64le.img", "loader", "symvers-*.ppc64le.gz", "System.map-*.ppc64le", "vmlinuz-*.ppc64le"}
+	bootDirFiles := []string{"config-*.ppc64le", "efi", "grub2", "initramfs-*.ppc64le.img", "loader", "symvers-*.ppc64le.*", "System.map-*.ppc64le", "vmlinuz-*.ppc64le"}
 	for _, file := range bootDirFiles {
 		exist, err := checkFileExists(filepath.Join(mnt, "boot", file))
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Added fix for handling the file extensions in the boot directory.

In Centos 9 and below version file extensions of `symvers-*.ppc64le` file is `gz `  whereas in Centos10  it is `xz`
Hence updated the file check

boot directory files in Centos 10 are as below
```
-rw-r--r--.  1 root root   180996 Feb  6 19:00 config-6.12.0-51.el10.ppc64le
drwxr-xr-x.  3 root root       17 Feb 10 00:12 efi
drwx------.  5 root root      118 Feb 10 00:14 grub2
-rw-------.  1 root root 61360501 Feb 10 00:15 initramfs-6.12.0-51.el10.ppc64le.img
drwxr-xr-x.  3 root root       21 Feb 10 00:13 loader
-rw-r--r--.  1 root root   211880 Feb 10 00:14 symvers-6.12.0-51.el10.ppc64le.xz
-rw-r--r--.  1 root root  5182183 Feb  6 19:00 System.map-6.12.0-51.el10.ppc64le
-rwxr-xr-x.  1 root root 48094960 Feb  6 19:00 vmlinuz-6.12.0-51.el10.ppc64le
-rw-r--r--.  1 root root      161 Feb  6 19:00 .vmlinuz-6.12.0-51.el10.ppc64le.hmac
```

Centos 9 boot directory files are as below
```
-rw-r--r--.  1 root root   166962 Feb  7 13:35 config-5.14.0-565.el9.ppc64le
drwxr-xr-x.  3 root root       17 Feb  9 23:20 efi
drwx------.  5 root root      118 Feb  9 23:23 grub2
-rw-------.  1 root root 61939531 Feb  9 23:23 initramfs-5.14.0-565.el9.ppc64le.img
drwxr-xr-x.  3 root root       21 Feb  9 23:22 loader
lrwxrwxrwx.  1 root root       46 Feb  9 23:22 symvers-5.14.0-565.el9.ppc64le.gz 
-rw-------.  1 root root  5822577 Feb  7 13:35 System.map-5.14.0-565.el9.ppc64le
-rwxr-xr-x.  1 root root 47026582 Feb  7 13:35 vmlinuz-5.14.0-565.el9.ppc64le
-rw-r--r--.  1 root root      161 Feb  7 13:35 .vmlinuz-5.14.0-565.el9.ppc64le.hmac
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://github.com/ppc64le-cloud/pvsadm/issues/725

**Special notes for your reviewer**:

**Output/Demonstration
<!--  Please feel free to add the demonstrations/changes the PR carries in this section.
-->

```release-note

```