### PR TITLE
RHEL/CentOS: Update SELinux Contexts without Rebooting by Using setfiles Command

### DIFF
--- a/cmd/image/qcow2ova/prep/templates.go
+++ b/cmd/image/qcow2ova/prep/templates.go
@@ -85,7 +85,7 @@ subscription-manager clean
 rpm -e ibm-power-repo-*.noarch
 
 mv /etc/resolv.conf.orig /etc/resolv.conf || true
-touch /.autorelabel
+setfiles -F /etc/selinux/targeted/contexts/files/file_contexts /
 `
 
 var CloudConfig = `# latest file from cloud-init-22.1-1.el8.noarch


### PR DESCRIPTION
This PR update setup script to avoid a reboot when updating SELinux contexts. The change replaces the `touch /.autorelabel` command with `setfiles -F /etc/selinux/targeted/contexts/files/file_contexts /`, which applies the required SELinux file context updates without needing a system reboot. This reduces setup time and eliminates the need for an additional system restart after completing the setup
