### PR TITLE
Revert PR-788 RHEL/CentOS: Update SELinux Contexts without Rebooting by Using setfiles Command

### DIFF
--- a/cmd/image/qcow2ova/prep/templates.go
+++ b/cmd/image/qcow2ova/prep/templates.go
@@ -85,7 +85,7 @@ subscription-manager clean
 rpm -e ibm-power-repo-*.noarch
 
 mv /etc/resolv.conf.orig /etc/resolv.conf || true
-setfiles -F /etc/selinux/targeted/contexts/files/file_contexts /
+touch /.autorelabel
 `
 
 var CloudConfig = `# latest file from cloud-init-22.1-1.el8.noarch


### PR DESCRIPTION
**What this PR does / why we need it**:

Revert PR #788 -RHEL/CentOS: Update SELinux Contexts without Rebooting by Using setfiles Command 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #812 

**Special notes for your reviewer**:


**Output/Demonstration
<!--  Please feel free to add the demonstrations/changes the PR carries in this section.
-->
setfiles relabels all system files during the build itself, so the VM does not need to relabel on first boot. However its Its failing for the new files we add during the build because they aren’t in the default SELinux policy. Hence reverting this this change.