### PR TITLE
Add a feature to pass user provided files during qcow2ova image conversion

### DIFF
--- a/cmd/image/qcow2ova/prep/prepare.go
+++ b/cmd/image/qcow2ova/prep/prepare.go
@@ -16,6 +16,7 @@ package prep
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,7 +35,7 @@ var (
 // - Install and configure multipath for rootfs
 // - Install all the required modules for PowerVM
 // - Sets the root password
-func prepare(mnt, volume, dist, rhnuser, rhnpasswd, rootpasswd string) error {
+func prepare(mnt, volume, dist, rhnuser, rhnpasswd, rootpasswd, writeToDirPath string, writeFilesList []string) error {
 	lo, err := setupLoop(volume)
 	if err != nil {
 		return err
@@ -144,6 +145,27 @@ func prepare(mnt, volume, dist, rhnuser, rhnpasswd, rootpasswd string) error {
 		return err
 	}
 
+	// Write user provided files to given path in the image
+	if len(writeFilesList) > 0 {
+		imageWritePath := filepath.Join(mnt, writeToDirPath)
+		// Clean paths to resolve relative components
+		cleanMnt := filepath.Clean(mnt)
+		cleanImageWritePath := filepath.Clean(imageWritePath)
+		if cleanImageWritePath != cleanMnt && !strings.HasPrefix(cleanImageWritePath, cleanMnt+"/") {
+			return fmt.Errorf("write-to-dir-path %q escapes the image mount root", writeToDirPath)
+		}
+		if err := os.MkdirAll(imageWritePath, 0755); err != nil {
+			return fmt.Errorf("failed to create directory %s: %w", imageWritePath, err)
+		}
+		for _, filePath := range writeFilesList {
+			base := filepath.Base(filePath)
+			destinationPath := filepath.Join(imageWritePath, base)
+			if err := copyFiles(filePath, destinationPath); err != nil {
+				return err
+			}
+		}
+	}
+
 	err = Chroot(mnt)
 	if err != nil {
 		return err
@@ -169,7 +191,7 @@ func UmountHostPartitions(mnt string) {
 	}
 }
 
-func Prepare4capture(mnt, volume, dist, rhnuser, rhnpasswd, rootpasswd string) error {
+func Prepare4capture(mnt, volume, dist, rhnuser, rhnpasswd, rootpasswd, writeToDirPath string, writeFilesList []string) error {
 	//cwd, err := os.Getwd()
 	//if err != nil {
 	//	return err
@@ -177,11 +199,89 @@ func Prepare4capture(mnt, volume, dist, rhnuser, rhnpasswd, rootpasswd string) e
 	//defer os.Chdir(cwd)
 	switch dist := strings.ToLower(dist); dist {
 	case "rhel", "centos":
-		return prepare(mnt, volume, dist, rhnuser, rhnpasswd, rootpasswd)
+		return prepare(mnt, volume, dist, rhnuser, rhnpasswd, rootpasswd, writeToDirPath, writeFilesList)
 	case "coreos":
 		klog.Info("No image preparation required for the coreos.")
 		return nil
 	default:
 		return fmt.Errorf("not a supported distro: %s", dist)
 	}
+}
+
+func copyFiles(src, dest string) error {
+	fileInfo, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+
+	if fileInfo.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("symlinks are not supported: %s", src)
+	}
+
+	if fileInfo.IsDir() {
+		return copyDir(src, dest)
+	}
+
+	return copyFile(src, dest, fileInfo)
+}
+
+func copyFile(src, dest string, srcInfo os.FileInfo) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dest, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, srcInfo.Mode())
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+
+	return out.Close()
+}
+
+func copyDir(src, dest string) error {
+	srcInfo, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(dest, srcInfo.Mode()); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", dest, err)
+	}
+
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		srcPath := filepath.Join(src, entry.Name())
+		destPath := filepath.Join(dest, entry.Name())
+
+		entryInfo, err := entry.Info()
+		if err != nil {
+			return err
+		}
+
+		if entryInfo.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("symlinks are not supported: %s", srcPath)
+		}
+
+		if entry.IsDir() {
+			if err := copyDir(srcPath, destPath); err != nil {
+				return err
+			}
+		} else {
+			if err := copyFile(srcPath, destPath, entryInfo); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }

--- a/cmd/image/qcow2ova/prep/prepare_test.go
+++ b/cmd/image/qcow2ova/prep/prepare_test.go
@@ -1,0 +1,458 @@
+// Copyright 2021 IBM Corp
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package prep
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ── copyFiles / copyFile / copyDir ────────────────────────────────────────────
+
+func TestCopyFile_Basic(t *testing.T) {
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "src.txt")
+	dst := filepath.Join(tmp, "dst.txt")
+
+	if err := os.WriteFile(src, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyFiles(src, dst); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "hello" {
+		t.Errorf("content mismatch: got %q", got)
+	}
+}
+
+func TestCopyFile_PreservesPermissions(t *testing.T) {
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "exec.sh")
+	dst := filepath.Join(tmp, "exec_copy.sh")
+
+	if err := os.WriteFile(src, []byte("#!/bin/sh"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyFiles(src, dst); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode() != 0755 {
+		t.Errorf("expected mode 0755, got %v", info.Mode())
+	}
+}
+
+func TestCopyFiles_RejectsSymlink(t *testing.T) {
+	tmp := t.TempDir()
+	real := filepath.Join(tmp, "real.txt")
+	link := filepath.Join(tmp, "link.txt")
+
+	if err := os.WriteFile(real, []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+
+	err := copyFiles(link, filepath.Join(tmp, "dst.txt"))
+	if err == nil {
+		t.Fatal("expected error for symlink, got nil")
+	}
+	if !strings.Contains(err.Error(), "symlinks are not supported") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestCopyDir_Basic(t *testing.T) {
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "srcdir")
+	dst := filepath.Join(tmp, "dstdir")
+
+	if err := os.Mkdir(src, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "a.txt"), []byte("aaa"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "b.txt"), []byte("bbb"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyFiles(src, dst); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, name := range []string{"a.txt", "b.txt"} {
+		data, err := os.ReadFile(filepath.Join(dst, name))
+		if err != nil {
+			t.Fatalf("missing file %s: %v", name, err)
+		}
+		if name == "a.txt" && string(data) != "aaa" {
+			t.Errorf("a.txt: got %q", data)
+		}
+		if name == "b.txt" && string(data) != "bbb" {
+			t.Errorf("b.txt: got %q", data)
+		}
+	}
+}
+
+func TestCopyDir_Nested(t *testing.T) {
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "srcdir")
+	sub := filepath.Join(src, "sub")
+	dst := filepath.Join(tmp, "dstdir")
+
+	if err := os.MkdirAll(sub, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "nested.txt"), []byte("nested"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyFiles(src, dst); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dst, "sub", "nested.txt"))
+	if err != nil {
+		t.Fatalf("missing nested file: %v", err)
+	}
+	if string(data) != "nested" {
+		t.Errorf("nested.txt: got %q", data)
+	}
+}
+
+func TestCopyDir_RejectsSymlinkInsideDir(t *testing.T) {
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "srcdir")
+	real := filepath.Join(tmp, "real.txt")
+	link := filepath.Join(src, "link.txt")
+	dst := filepath.Join(tmp, "dstdir")
+
+	if err := os.Mkdir(src, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(real, []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+
+	err := copyFiles(src, dst)
+	if err == nil {
+		t.Fatal("expected error for symlink inside dir, got nil")
+	}
+	if !strings.Contains(err.Error(), "symlinks are not supported") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+// path-escape guard (the logic extracted from prepare())
+// checkWritePath mirrors the guard in prepare() so we can unit-test it
+// without needing a mounted image.
+func checkWritePath(mnt, writeToDirPath string) error {
+	imageWritePath := filepath.Join(mnt, writeToDirPath)
+	cleanMnt := filepath.Clean(mnt)
+	cleanImageWritePath := filepath.Clean(imageWritePath)
+	if cleanImageWritePath != cleanMnt && !strings.HasPrefix(cleanImageWritePath, cleanMnt+"/") {
+		return fmt.Errorf("write-to-dir-path %q escapes the image mount root", writeToDirPath)
+	}
+	return nil
+}
+
+func TestPathEscapeGuard(t *testing.T) {
+	mnt := "/tmp/qcow2ovaXXX/mnt"
+
+	cases := []struct {
+		name        string
+		path        string
+		expectError bool
+	}{
+		{"normal absolute path", "/home/user", false},
+		{"normal relative path", "home/user", false},
+		{"root of mount", "/", false},
+		{"dot (mnt itself)", ".", false},
+		{"escape with ..", "../../etc", true},
+		{"escape with leading slash+..", "/../../etc", true},
+		{"escape to parent", "../", true},
+		{"escape sibling dir", "../sibling", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkWritePath(mnt, tc.path)
+			if tc.expectError && err == nil {
+				t.Errorf("expected escape error, got nil")
+			}
+			if !tc.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// copyFiles edge cases
+
+func TestCopyFiles_NonExistentSource(t *testing.T) {
+	tmp := t.TempDir()
+	err := copyFiles(filepath.Join(tmp, "does_not_exist.txt"), filepath.Join(tmp, "dst.txt"))
+	if err == nil {
+		t.Fatal("expected error for missing source, got nil")
+	}
+}
+
+func TestCopyFile_OverwritesExisting(t *testing.T) {
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "src.txt")
+	dst := filepath.Join(tmp, "dst.txt")
+
+	// pre-populate destination with different content
+	if err := os.WriteFile(dst, []byte("old content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(src, []byte("new"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyFiles(src, dst); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new" {
+		t.Errorf("expected truncated content %q, got %q", "new", got)
+	}
+}
+
+func TestCopyDir_Empty(t *testing.T) {
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "empty")
+	dst := filepath.Join(tmp, "emptydst")
+
+	if err := os.Mkdir(src, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyFiles(src, dst); err != nil {
+		t.Fatalf("unexpected error copying empty dir: %v", err)
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("destination dir not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("expected destination to be a directory")
+	}
+}
+
+func TestCopyDir_PreservesPermissions(t *testing.T) {
+	tmp := t.TempDir()
+	src := filepath.Join(tmp, "srcdir")
+	dst := filepath.Join(tmp, "dstdir")
+
+	if err := os.Mkdir(src, 0750); err != nil {
+		t.Fatal(err)
+	}
+	// Read back the actual mode after umask is applied, so the assertion is
+	// not sensitive to the host umask setting.
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := copyFiles(src, dst); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	dstInfo, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dstInfo.Mode().Perm() != srcInfo.Mode().Perm() {
+		t.Errorf("expected dir mode %v, got %v", srcInfo.Mode().Perm(), dstInfo.Mode().Perm())
+	}
+}
+
+// writeFilesList integration: base-name stripping and empty-list no-op
+// writeFilesToImage mirrors the file-injection block in prepare() so it can be
+// tested without a mounted image or chroot.
+func writeFilesToImage(mnt, writeToDirPath string, writeFilesList []string) error {
+	if len(writeFilesList) == 0 {
+		return nil
+	}
+	imageWritePath := filepath.Join(mnt, writeToDirPath)
+	cleanMnt := filepath.Clean(mnt)
+	cleanImageWritePath := filepath.Clean(imageWritePath)
+	if cleanImageWritePath != cleanMnt && !strings.HasPrefix(cleanImageWritePath, cleanMnt+"/") {
+		return fmt.Errorf("write-to-dir-path %q escapes the image mount root", writeToDirPath)
+	}
+	if err := os.MkdirAll(imageWritePath, 0755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", imageWritePath, err)
+	}
+	for _, filePath := range writeFilesList {
+		base := filepath.Base(filePath)
+		destinationPath := filepath.Join(imageWritePath, base)
+		if err := copyFiles(filePath, destinationPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func TestWriteFilesToImage_CopiesFiles(t *testing.T) {
+	tmp := t.TempDir()
+	mnt := filepath.Join(tmp, "mnt")
+	if err := os.Mkdir(mnt, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// source files in a separate directory
+	srcDir := filepath.Join(tmp, "src")
+	if err := os.Mkdir(srcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	f1 := filepath.Join(srcDir, "file1.txt")
+	f2 := filepath.Join(srcDir, "file2.txt")
+	if err := os.WriteFile(f1, []byte("one"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(f2, []byte("two"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writeFilesToImage(mnt, "/home/user", []string{f1, f2}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for name, want := range map[string]string{"file1.txt": "one", "file2.txt": "two"} {
+		got, err := os.ReadFile(filepath.Join(mnt, "home", "user", name))
+		if err != nil {
+			t.Fatalf("missing %s: %v", name, err)
+		}
+		if string(got) != want {
+			t.Errorf("%s: got %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestWriteFilesToImage_BaseNameStripping(t *testing.T) {
+	// A file at /deep/nested/path/report.log should land as report.log, not
+	// reproduce the full source path inside the image.
+	tmp := t.TempDir()
+	mnt := filepath.Join(tmp, "mnt")
+	if err := os.MkdirAll(mnt, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	deep := filepath.Join(tmp, "a", "b", "c")
+	if err := os.MkdirAll(deep, 0755); err != nil {
+		t.Fatal(err)
+	}
+	src := filepath.Join(deep, "report.log")
+	if err := os.WriteFile(src, []byte("log"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writeFilesToImage(mnt, "/logs", []string{src}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Only the base name should exist at the target
+	dest := filepath.Join(mnt, "logs", "report.log")
+	if _, err := os.Stat(dest); err != nil {
+		t.Fatalf("expected %s to exist: %v", dest, err)
+	}
+}
+
+func TestWriteFilesToImage_EmptyListIsNoop(t *testing.T) {
+	tmp := t.TempDir()
+	mnt := filepath.Join(tmp, "mnt")
+	if err := os.Mkdir(mnt, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := writeFilesToImage(mnt, "/home/user", []string{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The target directory must NOT have been created
+	entries, err := os.ReadDir(mnt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected mnt to be empty, got %d entries", len(entries))
+	}
+}
+
+func TestWriteFilesToImage_EscapingPathRejected(t *testing.T) {
+	tmp := t.TempDir()
+	mnt := filepath.Join(tmp, "mnt")
+	if err := os.Mkdir(mnt, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// empty list short-circuits before the guard — use a non-empty list
+	src := filepath.Join(tmp, "x.txt")
+	if err := os.WriteFile(src, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	err := writeFilesToImage(mnt, "../../etc", []string{src})
+	if err == nil {
+		t.Fatal("expected escape error, got nil")
+	}
+	if !strings.Contains(err.Error(), "escapes the image mount root") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// Prepare4capture distro routing
+func TestPrepare4capture_UnsupportedDistro(t *testing.T) {
+	err := Prepare4capture("/mnt", "/dev/null", "ubuntu", "", "", "", "", nil)
+	if err == nil {
+		t.Fatal("expected error for unsupported distro, got nil")
+	}
+	if !strings.Contains(err.Error(), "not a supported distro") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestPrepare4capture_DistroIsCaseInsensitive(t *testing.T) {
+	// "COREOS" (uppercase) must be treated identically to "coreos" — it should
+	// return nil (no-op) rather than "not a supported distro".
+	err := Prepare4capture("/mnt", "/dev/null", "COREOS", "", "", "", "", nil)
+	if err != nil {
+		t.Errorf("expected nil for coreos (case-insensitive), got: %v", err)
+	}
+}

--- a/cmd/image/qcow2ova/qcow2ova.go
+++ b/cmd/image/qcow2ova/qcow2ova.go
@@ -60,6 +60,9 @@ Examples:
   # Step 2 - Make the necessary changes to the above generated template file(bash shell script) - image-prep.template
   # Step 3 - Run the qcow2ova with the modified image preparation template
   pvsadm image qcow2ova --image-name centos-82 --image-dist centos --image-url /root/CentOS-8-GenericCloud-8.2.2004-20200611.2.ppc64le.qcow2 --prep-template image-prep.template
+  
+  # For adding custom files to the image, run the qcow2ova with flags --write-files-list and --write-to-dir-path
+  pvsadm image qcow2ova --image-name centos-82 --image-dist centos --image-url /root/CentOS-8-GenericCloud-8.2.2004-20200611.2.ppc64le.qcow2 --prep-template image-prep.template --write-files-list a.txt,b.log --write-to-dir-path /home/user
  
   # Customize the cloud config and Convert image with user defined cloud config template.
   # Step 1 - Dump the default cloud config template
@@ -116,6 +119,15 @@ Qcow2 images location:
 		if !utils.Contains([]string{"rhel", "centos", "coreos"}, strings.ToLower(opt.ImageDist)) {
 			klog.Errorln("--image-dist is a mandatory flag and one of these [rhel, centos, coreos]")
 			os.Exit(1)
+		}
+
+		if len(opt.WriteFilesList) > 0 {
+			if opt.WriteToDirPath == "" {
+				return fmt.Errorf("--write-to-dir-path is required when --write-files-list is specified")
+			}
+			if strings.ToLower(opt.ImageDist) == "coreos" {
+				return fmt.Errorf("--write-files-list is not supported for coreos distro")
+			}
 		}
 
 		//Read the RHNUser and RHNPassword if empty
@@ -263,7 +275,7 @@ Qcow2 images location:
 		klog.Info("Resize completed")
 
 		klog.Info("Preparing the image")
-		err = prep.Prepare4capture(mnt, rawImg, opt.ImageDist, opt.RHNUser, opt.RHNPassword, opt.OSPassword)
+		err = prep.Prepare4capture(mnt, rawImg, opt.ImageDist, opt.RHNUser, opt.RHNPassword, opt.OSPassword, opt.WriteToDirPath, opt.WriteFilesList)
 		if err != nil {
 			return fmt.Errorf("failed while preparing the image for %s distro, err: %v", opt.ImageDist, err)
 		}
@@ -300,6 +312,8 @@ func init() {
 	Cmd.Flags().StringVar(&pkg.ImageCMDOptions.OSPassword, "os-password", "", "Root user password, will auto-generate the 12 bits password(applicable only for redhat and cento distro)")
 	Cmd.Flags().StringVarP(&pkg.ImageCMDOptions.TempDir, "temp-dir", "t", os.TempDir(), "Scratch space to use for OVA generation")
 	Cmd.Flags().StringVar(&pkg.ImageCMDOptions.PrepTemplate, "prep-template", "", "Image preparation script template, use --prep-template-default to print the default template(supported distros: rhel and centos)")
+	Cmd.Flags().StringSliceVar(&pkg.ImageCMDOptions.WriteFilesList, "write-files-list", []string{}, "List of files to be copied to the image")
+	Cmd.Flags().StringVar(&pkg.ImageCMDOptions.WriteToDirPath, "write-to-dir-path", "", "User provided directory path where the provided files will be copied to")
 	Cmd.Flags().BoolVar(&pkg.ImageCMDOptions.PrepTemplateDefault, "prep-template-default", false, "Prints the default image preparation script template, use --prep-template to set the custom template script(supported distros: rhel and centos)")
 	Cmd.Flags().StringSliceVar(&pkg.ImageCMDOptions.PreflightSkip, "skip-preflight-checks", []string{}, "Skip the preflight checks(e.g: diskspace, platform, tools) - dev-only option")
 	Cmd.Flags().BoolVar(&pkg.ImageCMDOptions.OSPasswordSkip, "skip-os-password", false, "Skip the root user password")

--- a/pkg/options.go
+++ b/pkg/options.go
@@ -52,6 +52,8 @@ type imageCMDOptions struct {
 	TempDir             string
 	PrepTemplate        string
 	PrepTemplateDefault bool
+	WriteFilesList      []string
+	WriteToDirPath      string
 	CloudConfig         string
 	CloudConfigDefault  bool
 	OSPasswordSkip      bool


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a feature to allow user to add custom files to the image built.
--write-files-list is a comma separated list of files and --write-to-dir-path is the path where the files are written in the built image

example: 
```
pvsadm image qcow2ova --image-name test-image --image-dist centos --image-url https://cloud.centos.org/centos/10-stream/ppc64le/images/CentOS-Stream-GenericCloud-10-latest.ppc64le.qcow2 --prep-template ./image-prep.template --write-files-list key.pub,files --write-to-dir-path /home/user
```

Tested the following scenarios
1. Copy multiple files and directories
2. Copy nested directories
3. If destination path doesn't exist, creates and copies to it

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #811 

**Special notes for your reviewer**:

**Output/Demonstration
<!--  Please feel free to add the demonstrations/changes the PR carries in this section.
-->

```release-note
Add a feature to pass user provided files during qcow2ova image conversion
```